### PR TITLE
Add script to sign commits

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -23,13 +23,6 @@ jobs:
           app-id: ${{ secrets.OS_BOTIFY_APP_ID }}
           private-key: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
 
-      # Set up GPG signing by following this: https://stackoverflow.com/a/74071223
-      # os-botify GitHub App ID can be found here: https://api.github.com/users/os-botify[bot]
-      - name: Set up git user
-        run: |
-          git config --global user.name "os-botify[bot]"
-          git config --global user.email "140437396+os-botify[bot]@users.noreply.github.com"
-
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
@@ -40,11 +33,78 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
+      # Don't commit the version bump, we will commit later
       - name: Update npm version
-        run: npm version patch
+        run: npm version patch --git-tag-version false
 
       - name: Set new version in GitHub ENV
         run: echo "NEW_VERSION=$(jq '.version' package.json)" >> $GITHUB_ENV
+
+      # Copied and edited from: https://github.com/joshjohanning-org/commit-sign-app/blob/main/.github/workflows/commit-sign.yml
+      - name: Created signed commit
+        run: |
+          #!/bin/bash
+          set -euxo pipefail
+
+          # Variables
+          repository="${{ inputs.repository }}" 
+          token="${{ steps.app-token.outputs.token }}"
+          file1_path="package.json"
+          file2_path="package-lock.json"
+
+          # Get the contents of the files; jq -Rs escapes new lines and quotes
+          file1_content=$(jq -Rs '.' $file1_path)
+          file2_content=$(jq -Rs '.' $file2_path)
+
+          # Get the latest commit
+          latest_commit=$(curl -s -H "Authorization: token $token" \
+            https://api.github.com/repos/$repository/git/refs/heads/main \
+            | jq -r '.object.sha')
+
+          # Get the tree of the latest commit
+          base_tree=$(curl -s -H "Authorization: token $token" \
+            https://api.github.com/repos/$repository/git/commits/$latest_commit \
+            | jq -r '.tree.sha')
+
+          # Create a new tree with the new files
+          tree=$(curl -s -H "Authorization: token $token" -X POST \
+            -d '{
+              "base_tree": "'"$base_tree"'",
+              "tree": [
+                {
+                  "path": "'"$file1_path"'",
+                  "mode": "100644",
+                  "type": "blob",
+                  "content": '"$file1_content"'
+                },
+                {
+                  "path": "'"$file2_path"'",
+                  "mode": "100644",
+                  "type": "blob",
+                  "content": '"$file2_content"'
+                }
+              ]
+            }' https://api.github.com/repos/$repository/git/trees)
+
+          # Get the SHA of the new tree
+          new_tree_sha=$(echo $tree | jq -r '.sha')
+
+          # Create a new commit pointing to the new tree
+          commit=$(curl -sf -H "Authorization: token $token" -X POST \
+            -d '{
+              "message": "Add multiple files",
+              "tree": "'"$new_tree_sha"'",
+              "parents": ["'"$latest_commit"'"]
+            }' https://api.github.com/repos/$repository/git/commits)
+
+          # Get the SHA of the new commit
+          new_commit_sha=$(echo $commit | jq -r '.sha')
+
+          # Update the reference of the branch to point to the new commit
+          curl -s -H "Authorization: token $token" -X PATCH \
+            -d '{
+              "sha": "'"$new_commit_sha"'"
+            }' https://api.github.com/repos/$repository/git/refs/heads/main
 
       - name: Push branch and publish tags
         run: git push origin main && git push --tags


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Adds a script that will sign commits for us, using the GitHub API as recommended by GitHub support staff.

I read https://github.com/orgs/community/discussions/50055 and found an example here: https://github.com/joshjohanning-org/commit-sign-app/blob/main/.github/workflows/commit-sign.yml

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173