### PR TITLE
Create a file to send to the API as curl was complaining our arguments were too long

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -66,25 +66,27 @@ jobs:
             https://api.github.com/repos/$repository/git/commits/$latest_commit \
             | jq -r '.tree.sha')
 
+          # Create a file of our JSON to send as we can't send it as a string as it's too big
+          echo '{
+            "base_tree": "'"$base_tree"'",
+            "tree": [
+              {
+                "path": "'"$file1_path"'",
+                "mode": "100644",
+                "type": "blob",
+                "content": '"$file1_content"'
+              },
+              {
+                "path": "'"$file2_path"'",
+                "mode": "100644",
+                "type": "blob",
+                "content": '"$file2_content"'
+              }
+            ]
+          }' > tree_request.json
+
           # Create a new tree with the new files
-          tree=$(curl -s -H "Authorization: token $token" -X POST \
-            -d '{
-              "base_tree": "'"$base_tree"'",
-              "tree": [
-                {
-                  "path": "'"$file1_path"'",
-                  "mode": "100644",
-                  "type": "blob",
-                  "content": '"$file1_content"'
-                },
-                {
-                  "path": "'"$file2_path"'",
-                  "mode": "100644",
-                  "type": "blob",
-                  "content": '"$file2_content"'
-                }
-              ]
-            }' https://api.github.com/repos/$repository/git/trees)
+          tree=$(curl -s -H "Authorization: token $token" -X POST -d @tree_request.json https://api.github.com/repos/$repository/git/trees)
 
           # Get the SHA of the new tree
           new_tree_sha=$(echo $tree | jq -r '.sha')


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Was receiving the error: `/usr/bin/curl: Argument list too long`, so hopefully saving our request to a file, then passing that in to `curl` will fix the error.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173