### PR TITLE
Fetch main and fix string escaping

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -95,7 +95,7 @@ jobs:
           # Create a new commit pointing to the new tree
           commit=$(curl -sf -H "Authorization: token $token" -X POST \
             -d '{
-              "message": "Update version to: $version",
+              "message": "Update version to: '"$version"'",
               "tree": "'"$new_tree_sha"'",
               "parents": ["'"$latest_commit"'"]
             }' https://api.github.com/repos/$repository/git/commits)
@@ -109,6 +109,9 @@ jobs:
               "sha": "'"$new_commit_sha"'"
             }' https://api.github.com/repos/$repository/git/refs/heads/main
           
+          # Fetch the commit that was made via the API
+          git fetch origin main   
+
           # Tag new_commit_sha with our new version
           git tag -a $version $new_commit_sha
           


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fixes two issues found testing here: https://github.com/Expensify/eslint-config-expensify/actions/runs/11370056035

1. Tag was failing with `fatal: bad object type`, which hopefully will be fixed by `git fetch origin main`
2. Commit messages was off

![Google Chrome 2024-10-16 at 10 46 30](https://github.com/user-attachments/assets/d3a7cf35-87bc-48a3-99d7-30658f664d0a)


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173
