### PR TITLE
Set up bot user's git information

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -109,6 +109,11 @@ jobs:
               "sha": "'"$new_commit_sha"'"
             }' https://api.github.com/repos/$repository/git/refs/heads/main
           
+          # Set up git user info so we can push a tag
+          # os-botify[bot] GitHub App ID can be found here: https://api.github.com/users/os-botify[bot]
+          git config --global user.name "os-botify[bot]"
+          git config --global user.email "140437396+os-botify[bot]@users.noreply.github.com"
+          
           # Fetch the commit that was made via the API
           git fetch origin main   
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Error:

```
Committer identity unknown
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.
fatal: empty ident name (for <runner@fv-az1106-509.eyzkv0hxxq4uhofmll1wi1pi3e.ex.internal.cloudapp.net>) not allowed
```

Solution: Set up the bot users information in git.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173