### PR TITLE
Use env variables directly in order to prevent URL error

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -134,6 +134,6 @@ jobs:
       - name: Comment on PR
         run: |
           gh pr comment ${{ inputs.pull_request_number }} --repo ${{ inputs.repository }} \ 
-            --body ":rocket: Published in [${{ env.NEW_VERSION }}](https://www.npmjs.com/package/${{ env.NAME }}/v/${{ env.NEW_VERSION }}) :tada:"
+            --body ":rocket: Published in [$NEW_VERSION](https://www.npmjs.com/package/$NAME/v/$NEW_VERSION) :tada:"
         env:
           GITHUB_TOKEN: ${{ steps.generateAppToken.outputs.token }}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
I believe that we can use the environment variables directly as seen here to prevent this URL from using strings and confusing the `gh` command

![Google Chrome 2024-10-16 at 13 28 49](https://github.com/user-attachments/assets/10ee3388-60a4-4fe5-b030-fc2eded8e17b)


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173

