### PR TITLE
Add a build flag to enable shared workflow in `react-native-onyx`

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -161,6 +161,6 @@ jobs:
 
       - name: Comment on PR
         run: |
-          gh pr comment ${{steps.get_issue_number.outputs.result}} --repo ${{ inputs.repository }} --body ":rocket: Published to [npm](https://www.npmjs.com/) in ["${{ env.NEW_VERSION }}"](https://www.npmjs.com/package/"${{ env.NAME }}"/v/"${{ env.NEW_VERSION }}") :tada:"
+          gh pr comment ${{steps.pull_request_number.outputs.result}} --repo ${{ inputs.repository }} --body ":rocket: Published to [npm](https://www.npmjs.com/) in ["${{ env.NEW_VERSION }}"](https://www.npmjs.com/package/"${{ env.NAME }}"/v/"${{ env.NEW_VERSION }}") :tada:"
         env:
           GITHUB_TOKEN: ${{ steps.generateAppToken.outputs.token }}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -8,10 +8,6 @@ on:
         default: ${{ github.repository }}
         required: true
         type: string
-      pull_request_number:
-        description: 'Pull request number that was merged to trigger this workflow'
-        required: true
-        type: number
       should_run_build:
         description: 'True if we should run npm run build for the package'
         default: false
@@ -144,8 +140,27 @@ jobs:
       - name: Set name version in GitHub ENV
         run: echo "NAME=$(jq '.name' package.json)" >> $GITHUB_ENV
 
+      - uses: actions/github-script@v7
+        id: pull_request_number
+        with:
+          script: |
+            if (context.issue.number) {
+              // Return issue number if present
+              return context.issue.number;
+            } else {
+              // Otherwise return issue number from commit
+              return (
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  commit_sha: context.sha,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                })
+              ).data[0].number;
+            }
+          result-encoding: string
+
       - name: Comment on PR
         run: |
-          gh pr comment ${{ inputs.pull_request_number }} --repo ${{ inputs.repository }} --body ":rocket: Published in ["${{ env.NEW_VERSION }}"](https://www.npmjs.com/package/"${{ env.NAME }}"/v/"${{ env.NEW_VERSION }}") :tada:"
+          gh pr comment ${{steps.get_issue_number.outputs.result}} --repo ${{ inputs.repository }} --body ":rocket: Published to [npm](https://www.npmjs.com/) in ["${{ env.NEW_VERSION }}"](https://www.npmjs.com/package/"${{ env.NAME }}"/v/"${{ env.NEW_VERSION }}") :tada:"
         env:
           GITHUB_TOKEN: ${{ steps.generateAppToken.outputs.token }}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -4,13 +4,19 @@ on:
   workflow_call:
     inputs:
       repository:
+        description: 'Repository name with owner. For example: "Expensify/eslint-config-expensify"'
+        default: ${{ github.repository }}
         required: true
         type: string
-        description: 'Repository name with owner. For example: "Expensify/eslint-config-expensify"'
       pull_request_number:
+        description: 'Pull request number that was merged to trigger this workflow'
         required: true
         type: number
-        description: 'Pull request number that was merged to trigger this workflow'
+      should_run_build:
+        description: 'True if we should run npm run build for the package'
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   version:
@@ -32,6 +38,9 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm packages
+        run: npm ci
 
       # Don't commit the version bump, we will commit later
       - name: Update npm version
@@ -122,6 +131,10 @@ jobs:
           
           # Push the new tag
           git push origin tag $version
+
+      - name: Optionally run `npm run build`
+        if: ${{ inputs.should_run_build }}
+        run: npm run build
 
       - name: Publish to npm
         run: npm publish

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -140,7 +140,8 @@ jobs:
       - name: Set name version in GitHub ENV
         run: echo "NAME=$(jq '.name' package.json)" >> $GITHUB_ENV
 
-      - uses: actions/github-script@v7
+      - name: Get Pull Request Number
+        uses: actions/github-script@v7
         id: pull_request_number
         with:
           script: |

--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ jobs:
     with:
       # Repository name with owner. For example, Expensify/eslint-config-expensify
       # Required, String, default: ${{ github.repository }}
-      repository: 'Expensify/eslint-config-expensify'
-
-      # Pull request number to comment on when the npm package is published
-      # Required, Number
-      pull_request_number: 123
+      repository: ''
 
       # True if we should run npm run build for the package
       # Optional, Boolean, default: false

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# GitHub-Actions
+# Expensify Shared GitHub Actions workflows 🔄 
+
+## What is the repository used for?
+
+Expensify has multiple repositories that use the same GitHub Actions workflows. This repository centralizes and consolidates frequently used workflows to enhance security and maintain consistent standards across projects.
+
+## Usage
+
+### `npmPublish.yml`
+
+```yml
+jobs:
+  publish:
+    uses: Expensify/GitHub-Actions/.github/workflows/npmPublish.yml@main
+    secrets: inherit
+    with:
+      # Repository name with owner. For example, Expensify/eslint-config-expensify
+      # Required, String, default: ${{ github.repository }}
+      repository: 'Expensify/eslint-config-expensify'
+
+      # Pull request number to comment on when the npm package is published
+      # Required, Number
+      pull_request_number: 123
+
+      # True if we should run npm run build for the package
+      # Optional, Boolean, default: false
+      should_run_build: true
+```


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
* Adds a `should_run_build` flag in order to optionally run `npm run build` for repos that use typescript and require a build step
* Removes the need to pass in a pull request number and grabs it directly
* Add a readme to polish the project a bit more

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173

### Tests
1. Merge this PR
2. Merge [this PR](https://github.com/Expensify/eslint-config-expensify/pull/135) and verify the deploy runs correctly
