### PR TITLE
Do not require github repository, we will use the default value

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -6,7 +6,7 @@ on:
       repository:
         description: 'Repository name with owner. For example: "Expensify/eslint-config-expensify"'
         default: ${{ github.repository }}
-        required: true
+        required: false
         type: string
       should_run_build:
         description: 'True if we should run npm run build for the package'


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fixes error seen here: https://github.com/Expensify/eslint-config-expensify/actions/runs/11392661829

I had incorrectly assumed that the `default` param would work with a `required` variable, but it does not.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/432173