### PR TITLE
Create setupGitAsOSBotify callable action

### DIFF
--- a/.github/actions/setupGitForOSBotify/action.yml
+++ b/.github/actions/setupGitForOSBotify/action.yml
@@ -50,11 +50,6 @@ runs:
         git config user.name OSBotify
         git config user.email infra+osbotify@expensify.com
 
-    - name: Enable debug logs for git
-      shell: bash
-      if: runner.debug == '1'
-      run: echo "GIT_TRACE=true" >> "$GITHUB_ENV"
-
     - name: Sync clock
       shell: bash
       run: sudo sntp -sS time.windows.com

--- a/.github/actions/setupGitForOSBotify/action.yml
+++ b/.github/actions/setupGitForOSBotify/action.yml
@@ -35,6 +35,8 @@ runs:
     - name: Download OSBotify GPG key
       run: op read op://Mobile-Deploy-CI/OSBotify-private-key.asc/OSBotify-private-key.asc --force --out-file ./OSBotify-private-key.asc
       shell: bash
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: Import OSBotify GPG Key
       shell: bash

--- a/.github/actions/setupGitForOSBotify/action.yml
+++ b/.github/actions/setupGitForOSBotify/action.yml
@@ -1,0 +1,67 @@
+# This action configures Git for OSBotify.
+#
+# By default, the token it provides is a Github App for Github Authentication.
+# GitHub Apps have higher rate limits.
+#
+# If you only need a local git setup, you can skip that step with SETUP_AS_APP: false
+
+name: Setup Git for OSBotify
+description: Setup Git for OSBotify
+
+inputs:
+  OP_SERVICE_ACCOUNT_TOKEN:
+    description: 1Password service account token
+    required: true
+  OS_BOTIFY_APP_ID:
+    description: Application ID for OS Botify
+    required: false
+  SETUP_AS_APP:
+    description: Should we get an app token for OSBotify?
+    required: false
+    default: 'true'
+
+outputs:
+  # Do not try to use this for committing code. Use `secrets.OS_BOTIFY_COMMIT_TOKEN` instead
+  OS_BOTIFY_API_TOKEN:
+    description: Token to use for GitHub API interactions.
+    value: ${{ steps.generateToken.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install 1Password CLI
+      uses: 1password/install-cli-action@v1
+
+    - name: Download OSBotify GPG key
+      run: op read op://Mobile-Deploy-CI/OSBotify-private-key.asc/OSBotify-private-key.asc --force --out-file ./OSBotify-private-key.asc
+      shell: bash
+
+    - name: Import OSBotify GPG Key
+      shell: bash
+      run: gpg --import OSBotify-private-key.asc
+
+    - name: Set up git for OSBotify
+      shell: bash
+      run: |
+        git config user.signingkey AEE1036472A782AB
+        git config commit.gpgsign true
+        git config user.name OSBotify
+        git config user.email infra+osbotify@expensify.com
+
+    - name: Enable debug logs for git
+      shell: bash
+      if: runner.debug == '1'
+      run: echo "GIT_TRACE=true" >> "$GITHUB_ENV"
+
+    - name: Sync clock
+      shell: bash
+      run: sudo sntp -sS time.windows.com
+      if: runner.os == 'macOS'
+
+    - name: Generate a token
+      id: generateToken
+      if: inputs.SETUP_AS_APP == 'true'
+      uses: actions/create-github-app-token@9d97a4282b2c51a2f4f0465b9326399f53c890d4
+      with:
+        app-id: ${{ inputs.OS_BOTIFY_APP_ID }}
+        private-key: ${{ inputs.OS_BOTIFY_PRIVATE_KEY }}

--- a/.github/actions/setupGitForOSBotify/action.yml
+++ b/.github/actions/setupGitForOSBotify/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: 1password/install-cli-action@v1
 
     - name: Download OSBotify GPG key
-      run: op read op://Mobile-Deploy-CI/OSBotify-private-key.asc/OSBotify-private-key.asc --force --out-file ./OSBotify-private-key.asc
+      run: op read "op://Mobile-Deploy-CI/OSBotify-private-key.asc/OSBotify-private-key.asc" --force --out-file ./OSBotify-private-key.asc
       shell: bash
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
~~HOLD to make sure we have the secrets we need~~

We don't need any new secrets in this repo for this. Since it's an action not a workflow, secrets must be passed in as inputs.

### Details
Porting a version of this callable action to this repo, so that we can use it from E/App, Mobile-Expensify, and other repos.

### Related Issues
related to https://github.com/Expensify/App/issues/55403

### Manual Tests
Going to test this first in Mobile-Expensify in a new workflow to update the Mobile-Expensify submodule in E/App when changes are merged to main in Mobile-Expensify

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->