### PR TITLE
Add provenance to npm publish

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -22,6 +22,9 @@ on:
 jobs:
   version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Generate a GitHub App token
         id: generateAppToken
@@ -96,7 +99,7 @@ jobs:
         run: npm pack
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
### Details
Per request from Tomek: https://expensify.slack.com/archives/C06BDSWLDPB/p1738519013890919

Based on https://github.com/software-mansion/react-native-reanimated/pull/6890/files

### Related Issues
n/a

### Manual Tests
Merge this PR, then another one that triggers an npm publish. Make sure it works.

### Linked PRs
n/a