### PR TITLE
Add missing --global flag

### DIFF
--- a/setupGitForOSBotify/action.yml
+++ b/setupGitForOSBotify/action.yml
@@ -51,10 +51,10 @@ runs:
     - name: Set up git for OSBotify
       shell: bash
       run: |
-        git config user.signingkey AEE1036472A782AB
-        git config commit.gpgsign true
-        git config user.name OSBotify
-        git config user.email infra+osbotify@expensify.com
+        git config --global user.signingkey AEE1036472A782AB
+        git config --global commit.gpgsign true
+        git config --global user.name OSBotify
+        git config --global user.email infra+osbotify@expensify.com
 
     - name: Sync clock
       shell: bash


### PR DESCRIPTION
### Details
Fixing https://github.com/Expensify/App-Test-Fork/actions/runs/13296643347/job/37130020020. This change is already in the E/App version, we just failed to carry it over to the GitHub-Actions version.

### Related Issues
https://github.com/Expensify/App/issues/55403

### Manual Tests
Merge and retry CreateNewVersion in App-Test-Fork.