### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -107,7 +107,8 @@ jobs:
         run: echo "NAME=$(jq '.name' package.json)" >> "$GITHUB_ENV"
 
       - name: Get Pull Request Number
-        uses: actions/github-script@v7
+        # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: pull_request_number
         with:
           script: |

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -107,7 +107,7 @@ jobs:
         run: echo "NAME=$(jq '.name' package.json)" >> "$GITHUB_ENV"
 
       - name: Get Pull Request Number
-        # v7
+        # v7.0.1
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: pull_request_number
         with:

--- a/.github/workflows/shellCheck.yml
+++ b/.github/workflows/shellCheck.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Lint shell scripts with ShellCheck
         run: npm run shellCheck

--- a/.github/workflows/shellCheck.yml
+++ b/.github/workflows/shellCheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # v4
+        # 4.2.2
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Lint shell scripts with ShellCheck

--- a/.github/workflows/validateActions.yml
+++ b/.github/workflows/validateActions.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - uses: actions/setup-node@v4
 

--- a/.github/workflows/validateActions.yml
+++ b/.github/workflows/validateActions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # v4
+        # v4.2.2
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/CC7NECV4L/p1743022578963949, this pull request updates all mutable action references to use immutable commit hashes instead. This is a security measure to protect from supply chain attacks.