### PR TITLE
Validate GitHub actions in any repo

### DIFF
--- a/.github/scripts/actionlint.sh
+++ b/.github/scripts/actionlint.sh
@@ -15,6 +15,7 @@ readonly SCRIPT_DIR
 # To update the actionlint version, replace this file with the updated checksums file from the GitHub release
 readonly CHECKSUMS_FILE="$SCRIPT_DIR/actionlint_checksums.txt"
 readonly ACTIONLINT_PATH="$SCRIPT_DIR/actionlint"
+readonly REPO_ROOT="${REPO_ROOT:-.}"
 
 source "$SCRIPT_DIR/shellUtils.sh"
 
@@ -72,16 +73,17 @@ else
     # It's only possible to have one exit trap, so we have to update to include both items we wish to remove
     trap 'rm -rf "$TMPDIR" "$TARBALL"' EXIT
     tar -C "$TMPDIR" -xzf "$TARBALL"
-    mv "$TMPDIR/actionlint" "$SCRIPT_DIR/actionlint"
+    mv "$TMPDIR/actionlint" "$ACTIONLINT_PATH"
 
-    INSTALLED_VERSION="$("$SCRIPT_DIR/actionlint" -version | head -n 1)"
+    INSTALLED_VERSION="$("$ACTIONLINT_PATH" -version | head -n 1)"
     readonly INSTALLED_VERSION
     info "Successfully installed actionlint version $INSTALLED_VERSION" >&2
 fi
 
 info "Linting workflows..."
 echo
-if ! "$SCRIPT_DIR/actionlint" -color; then
+cd "$REPO_ROOT" || exit 1
+if ! "$ACTIONLINT_PATH" -color; then
     error "Workflows did not pass actionlint :("
     exit 1
 fi

--- a/.github/scripts/shellUtils.sh
+++ b/.github/scripts/shellUtils.sh
@@ -2,41 +2,50 @@
 
 # Check if GREEN has already been defined
 if [ -z "${GREEN+x}" ]; then
-    declare -r GREEN=$'\e[1;32m'
+    readonly GREEN=$'\e[1;32m'
+fi
+
+# Check if YELLOW has already been defined
+if [ -z "${YELLOW+x}" ]; then
+    readonly YELLOW=$'\e[1;33m'
 fi
 
 # Check if RED has already been defined
 if [ -z "${RED+x}" ]; then
-    declare -r RED=$'\e[1;31m'
+    readonly RED=$'\e[1;31m'
 fi
 
 # Check if BLUE has already been defined
 if [ -z "${BLUE+x}" ]; then
-    declare -r BLUE=$'\e[1;34m'
+    readonly BLUE=$'\e[1;34m'
 fi
 
 # Check if TITLE has already been defined
 if [ -z "${TITLE+x}" ]; then
-    declare -r TITLE=$'\e[1;4;34m'
+    readonly TITLE=$'\e[1;4;34m'
 fi
 
 # Check if RESET has already been defined
 if [ -z "${RESET+x}" ]; then
-    declare -r RESET=$'\e[0m'
+    readonly RESET=$'\e[0m'
 fi
 
-function success {
+function success() {
     echo "🎉 $GREEN$1$RESET"
 }
 
-function error {
+function warning() {
+    echo "⚠️ $YELLOW$1$RESET"
+}
+
+function error() {
     echo "💥 $RED$1$RESET"
 }
 
-function info {
+function info() {
     echo "$BLUE$1$RESET"
 }
 
-function title {
+function title() {
     printf "\n%s%s%s\n" "$TITLE" "$1" "$RESET"
 }

--- a/.github/workflows/validateActions.yml
+++ b/.github/workflows/validateActions.yml
@@ -10,9 +10,9 @@ jobs:
   validateSchemas:
     runs-on: ubuntu-latest
     steps:
-      # v4.2.2
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout repos
+        id: repo
+        uses: Expensify/GitHub-Actions/checkoutRepoAndGitHubActions@main
 
       # v4.3.0
       - name: Setup Node
@@ -20,27 +20,33 @@ jobs:
 
       # Install node to get the ajv-cli
       - name: Install node modules
-        run: npm ci
+        run: npm i -g ajv-cli@5.0.0
 
       - name: Validate action and workflow schemas
-        run: .github/scripts/validateWorkflowSchemas.sh
+        run: GitHub-Actions/.github/scripts/validateWorkflowSchemas.sh
+        env:
+          REPO_ROOT: ${{ steps.repo.outputs.NAME }}
 
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      # v4.2.2
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout repos
+        id: repo
+        uses: Expensify/GitHub-Actions/checkoutRepoAndGitHubActions@main
 
       - name: Lint workflows with actionlint
-        run: .github/scripts/actionlint.sh
+        run: GitHub-Actions/.github/scripts/actionlint.sh
+        env:
+          REPO_ROOT: ${{ steps.repo.outputs.NAME }}
 
   validateImmutableActionRefs:
     runs-on: ubuntu-latest
     steps:
-      # v4.2.2
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout repos
+        id: repo
+        uses: Expensify/GitHub-Actions/checkoutRepoAndGitHubActions@main
 
       - name: Validate actions refs are immutable
-        run: .github/scripts/validateImmutableActionRefs.sh
+        run: GitHub-Actions/.github/scripts/validateImmutableActionRefs.sh
+        env:
+          REPO_ROOT: ${{ steps.repo.outputs.NAME }}

--- a/checkoutRepoAndGitHubActions/action.yml
+++ b/checkoutRepoAndGitHubActions/action.yml
@@ -1,0 +1,26 @@
+name: Checkout target repo and GitHub Actions repo
+
+outputs:
+  NAME:
+    description: The target repo where this workflow is running (repo name w/o org prefix)
+    value: ${{ steps.repo.outputs.NAME }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get target repo name
+      id: repo
+      run: echo "NAME=$(basename ${{ github.repository }})" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    # v4.2.2
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        path: ${{ steps.repo.outputs.NAME }}
+
+    - name: Checkout Expensify/GitHub-Actions
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        repository: Expensify/GitHub-Actions
+        path: GitHub-Actions


### PR DESCRIPTION
### Details
This updates this workflow so that it can be run from other repos (enabled by a org-level ruleset). This has been tested here: https://github.com/Expensify/App/pull/61538

I am aware of an issue where this will not work to check for immutable actions in private repos for now.

### Related Issues
related to https://github.com/Expensify/Expensify/issues/484931

### Manual Tests
tested in https://github.com/Expensify/App/pull/61538

### Linked PRs
n/a