### PR TITLE
[No QA] Add v64 runner for WebE

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -9,6 +9,7 @@ self-hosted-runner:
     - macos-15-xlarge
     - macos-12
     - ubuntu-24.04-v4
+    - ubuntu-24.04-v64
 
 paths:
   '**/*':


### PR DESCRIPTION
### Details
Adding a large runner that's used in Web-E and Auth.

### Related Issues
n/a - https://github.com/Expensify/Web-Expensify/actions/runs/18579684111/job/52971954709?pr=49056

### Manual Tests
None.

### Linked PRs
None.