### PR TITLE
Skip validateActions for repos without workflows

### DIFF
--- a/.github/workflows/validateActions.yml
+++ b/.github/workflows/validateActions.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   validateSchemas:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.actor, '[bot]') && github.actor != 'MelvinBot' && github.actor != 'botify' && github.actor != 'OSBotify' }}
     steps:
       - name: Checkout repos
         id: repo
@@ -32,6 +33,7 @@ jobs:
 
   actionlint:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.actor, '[bot]') && github.actor != 'MelvinBot' && github.actor != 'botify' && github.actor != 'OSBotify' }}
     steps:
       - name: Checkout repos
         id: repo
@@ -48,6 +50,7 @@ jobs:
 
   validateImmutableActionRefs:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.actor, '[bot]') && github.actor != 'MelvinBot' && github.actor != 'botify' && github.actor != 'OSBotify' }}
     steps:
       - name: Checkout repos
         id: repo

--- a/.github/workflows/validateActions.yml
+++ b/.github/workflows/validateActions.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+      - '**/action.yml'
+      - '**/action.yaml'
 
 jobs:
   validateSchemas:


### PR DESCRIPTION
### Details
Skip this workflow for repos without GitHub actions or workflows. 

### Related Issues
n/a - https://github.com/Expensify/Expensidev/actions/runs/18595277671?pr=980

### Manual Tests
n/a - can't be tested locally