### PR TITLE
Remove NODE_AUTH_TOKEN from npm publish step

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -19,16 +19,12 @@ on:
         required: false
         type: boolean
 
-permissions:
-  id-token: write  # Required for OIDC: https://docs.npmjs.com/trusted-publishers
-  contents: read
-
 jobs:
-  version:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for OIDC: https://docs.npmjs.com/trusted-publishers
     steps:
       - name: Generate a GitHub App token
         id: generateAppToken

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -102,8 +102,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Set name version in GitHub ENV
         run: echo "NAME=$(jq '.name' package.json)" >> "$GITHUB_ENV"

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: boolean
 
+permissions:
+  id-token: write  # Required for OIDC: https://docs.npmjs.com/trusted-publishers
+  contents: read
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Removed NODE_AUTH_TOKEN from npm publish step since we will now use ODIC method to publish npm libraries.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Related https://github.com/Expensify/Expensify/issues/558148
