### PR TITLE
Re-add `NODE_AUTH_TOKEN` to npm publish step

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Set name version in GitHub ENV
         run: echo "NAME=$(jq '.name' package.json)" >> "$GITHUB_ENV"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Re-add node auth token back until we figure out how to publish via OIDC

Related https://github.com/Expensify/Expensify/issues/558148