### PR TITLE
Set an nvmrc file for node set up

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           registry-url: 'https://registry.npmjs.org'
+          node-version-file: '.nvmrc'
 
       - name: Install npm packages
         run: npm ci


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Sets an `nvmrc` file to use for when setting up node. I believe that this will use the `nvm` version of the repo that is calling this workflow, but need to test this live to confirm.
