### PR TITLE
Remove npm token to use OIDC to publish

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -103,8 +103,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Set name version in GitHub ENV
         run: echo "NAME=$(jq '.name' package.json)" >> "$GITHUB_ENV"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Remove the npm token and will rely on OIDC to publish all packages going forward.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Related: https://github.com/Expensify/Expensify/issues/558148
