### PR TITLE
Surface better errors with failed downloads

### DIFF
--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -63,7 +63,11 @@ else
 
     # --fail: Makes curl return error on HTTP errors (4xx, 5xx)
     # --location: Follow redirects
+    # --retry: Retry on transient errors
+    # --retry-delay: Wait between retry attempts
     curl --fail --location \
+        --retry 3 \
+        --retry-delay 3 \
         "https://github.com/rhysd/actionlint/releases/download/v${EXPECTED_VERSION}/${TARBALL_NAME}" \
         --output "$TARBALL"
     CURL_EXIT=$?
@@ -86,7 +90,7 @@ else
                 error "Download failed with curl exit code $CURL_EXIT" >&2
                 ;;
         esac
-        exit 1
+        exit "$CURL_EXIT"
     fi
 
     # Ensure tarball is cleaned up

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -60,8 +60,32 @@ else
     info "Downloading and verifying actionlint verion $EXPECTED_VERSION..." >&2
 
     readonly TARBALL="$SCRIPT_DIR/actionlint.tar.gz"
-    if ! curl -sL "https://github.com/rhysd/actionlint/releases/download/v${EXPECTED_VERSION}/${TARBALL_NAME}" -o "$TARBALL"; then
-        error "Unable to download actionlint binary"
+
+    # --fail: Makes curl return error on HTTP errors (4xx, 5xx)
+    # --location: Follow redirects
+    curl --fail --location \
+        "https://github.com/rhysd/actionlint/releases/download/v${EXPECTED_VERSION}/${TARBALL_NAME}" \
+        --output "$TARBALL"
+    CURL_EXIT=$?
+
+    if [[ $CURL_EXIT -ne 0 ]]; then
+        case $CURL_EXIT in
+            18)
+                error "Download failed: partial file transfer (network interrupted)" >&2
+                ;;
+            22)
+                error "Download failed: HTTP error from GitHub" >&2
+                ;;
+            28)
+                error "Download failed: operation timeout" >&2
+                ;;
+            56)
+                error "Download failed: network connection issue" >&2
+                ;;
+            *)
+                error "Download failed with curl exit code $CURL_EXIT" >&2
+                ;;
+        esac
         exit 1
     fi
 


### PR DESCRIPTION
### Details
It seems that https://github.com/Expensify/Web-Expensify/actions/runs/20137110958 failed due to a partial download. This resulted in a different checksum, which was an opaque error.

This PR tries to show clearer error messages if there's a problem with the download of actionlint.

### Related Issues
https://expensify.slack.com/archives/C03TQ48KC/p1765464626113279

### Manual Tests
<img width="743" height="567" alt="image" src="https://github.com/user-attachments/assets/a4984228-dd13-4255-93f2-c62f6e931a9d" />

### Linked PRs
None.