### PR TITLE
Update 1Password CLI action to fixed version

### DIFF
--- a/setup-certificate-1p/action.yml
+++ b/setup-certificate-1p/action.yml
@@ -1,0 +1,24 @@
+name: Set up mirror certificates
+description: Set up mirror certificates
+
+inputs:
+  OP_SERVICE_ACCOUNT_TOKEN:
+    description: 1Password service account token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install 1Password CLI
+      uses: 1password/install-cli-action@9a0c9dd934086b7ab1d90115d455bda1c53c2bdb
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
+
+    - name: Update SSL Certificates from 1Password
+      run: |
+        op document get --output expensify.ca.crt expensify.ca.crt && sudo cp expensify.ca.crt /usr/local/share/ca-certificates/expensify.ca.crt
+        sudo update-ca-certificates
+      shell: bash
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
+

--- a/setupGitForOSBotify/action.yml
+++ b/setupGitForOSBotify/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Install 1Password CLI
-      uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f
+      uses: 1password/install-cli-action@9a0c9dd934086b7ab1d90115d455bda1c53c2bdb
 
     - name: Download OSBotify GPG key
       run: op read "op://${{ inputs.OP_VAULT }}/OSBotify-private-key.asc/OSBotify-private-key.asc" --force --out-file ./OSBotify-private-key.asc


### PR DESCRIPTION
### Details
This PR updates all usages of the 1password/install-cli-action to use a fixed commit hash (9a0c9dd934086b7ab1d90115d455bda1c53c2bdb) that resolves an intermittent reliability issue. It also creates a new shared setup-certificate-1p action to eliminate duplicate implementations across repos.

### Related Issues
https://github.com/1Password/install-cli-action/issues/13

### Manual Tests
- Verified actionlint, validateImmutableActionRefs, and validateWorkflowSchemas all pass
- The new action combines 1Password CLI installation with certificate setup for internal mirror access

### Linked PRs
Once merged, this will unblock PRs in: Auth, ExpensifyBackupManager, ExpensifyTableManager, FuzzyBot, Web-Expensify, WhitelistDB, Bedrock, Web-Secure, PHP-Libs, App, actions-images