### PR TITLE
Make ssl cert optional

### DIFF
--- a/setup-certificate-1p/action.yml
+++ b/setup-certificate-1p/action.yml
@@ -5,6 +5,10 @@ inputs:
   OP_SERVICE_ACCOUNT_TOKEN:
     description: 1Password service account token
     required: true
+  NEEDS_SSL_CERTIFICATES:
+    description: Whether the action needs to set up SSL certificates
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -15,6 +19,7 @@ runs:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: Update SSL Certificates from 1Password
+      if: ${{ inputs.NEEDS_SSL_CERTIFICATES == 'true' }}
       run: |
         op document get --output expensify.ca.crt expensify.ca.crt && sudo cp expensify.ca.crt /usr/local/share/ca-certificates/expensify.ca.crt
         sudo update-ca-certificates

--- a/setup-certificate-1p/action.yml
+++ b/setup-certificate-1p/action.yml
@@ -5,7 +5,7 @@ inputs:
   OP_SERVICE_ACCOUNT_TOKEN:
     description: 1Password service account token
     required: true
-  NEEDS_SSL_CERTIFICATES:
+  SHOULD_LOAD_SSL_CERTIFICATES:
     description: Whether the action needs to set up SSL certificates
     required: false
     default: "true"
@@ -19,7 +19,7 @@ runs:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: Update SSL Certificates from 1Password
-      if: ${{ inputs.NEEDS_SSL_CERTIFICATES == 'true' }}
+      if: ${{ inputs.SHOULD_LOAD_SSL_CERTIFICATES == 'true' }}
       run: |
         op document get --output expensify.ca.crt expensify.ca.crt && sudo cp expensify.ca.crt /usr/local/share/ca-certificates/expensify.ca.crt
         sudo update-ca-certificates


### PR DESCRIPTION
### Details
Adding a flag to make loading the SSL cert for apt-mirror optional.

### Related Issues
https://expensify.slack.com/archives/C07J32337/p1765982694783999

### Manual Tests
None.

### Linked PRs
Will follow-up with an App PR.