### PR TITLE
Use Github-Actions action lint config if one is not present in the repo

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   CLA:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     # This job should only run for pull request comments or pull request target events (not issue comments)
     if: github.event.issue.pull_request || github.event_name == 'pull_request_target'
     steps:

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       id-token: write # Required for OIDC: https://docs.npmjs.com/trusted-publishers

--- a/.github/workflows/shellCheck.yml
+++ b/.github/workflows/shellCheck.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
         # 4.2.2

--- a/.github/workflows/validateActions.yml
+++ b/.github/workflows/validateActions.yml
@@ -9,7 +9,7 @@ on: pull_request
 
 jobs:
   validateSchemas:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: ${{ !contains(github.actor, '[bot]') && github.actor != 'MelvinBot' && github.actor != 'botify' && github.actor != 'OSBotify' }}
     steps:
       - name: Checkout repos
@@ -34,7 +34,7 @@ jobs:
         run: echo "::error::The validateWorkflowSchemas check failed! To run it locally, go to the root of ${{ steps.repo.outputs.NAME }} and run <path_to_github_actions_repo>/scripts/validateWorkflowSchemas.sh"
 
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: ${{ !contains(github.actor, '[bot]') && github.actor != 'MelvinBot' && github.actor != 'botify' && github.actor != 'OSBotify' }}
     steps:
       - name: Checkout repos
@@ -51,7 +51,7 @@ jobs:
         run: echo "::error::The actionlint check failed! To run it locally, go to the root of ${{ steps.repo.outputs.NAME }} and run <path_to_github_actions_repo>/scripts/actionlint.sh"
 
   validateImmutableActionRefs:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: ${{ !contains(github.actor, '[bot]') && github.actor != 'MelvinBot' && github.actor != 'botify' && github.actor != 'OSBotify' }}
     steps:
       - name: Checkout repos

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -2,7 +2,7 @@
 #################################################################
 #    Lint workflows with https://github.com/rhysd/actionlint    #
 #################################################################
-
+set -x
 # Verify that shellcheck is installed (preinstalled on GitHub Actions runners)
 if ! command -v shellcheck &>/dev/null; then
     error "This script requires shellcheck. Please install it and try again"
@@ -121,12 +121,13 @@ echo
 cd "$REPO_ROOT" || exit 1
 
 # If a repo has it's own action lint config, use that. Otherwise, use the one in this repo.
-$CONFIG=""
+CONFIG=""
 if [[ ! -f "$REPO_ROOT/.github/actionlint.yml" ]] && [[ ! -f "$REPO_ROOT/.github/actionlint.yaml" ]]; then
-    CONFIG="-config-file $SCRIPT_DIR/../.github/actionlint.yml"
+    CONFIG=" -config-file $(readlink -f $SCRIPT_DIR/../.github/actionlint.yml)"
+    info "Using default Github-Actions repo actionlint.yml" >&2
 fi
 
-if ! "$ACTIONLINT_PATH" -color "$CONFIG"; then
+if ! "$ACTIONLINT_PATH" ${CONFIG} -color; then
     error "Workflows did not pass actionlint :("
     exit 1
 fi

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -119,7 +119,14 @@ fi
 info "Linting workflows..."
 echo
 cd "$REPO_ROOT" || exit 1
-if ! "$ACTIONLINT_PATH" -color; then
+
+# If a repo has it's own action lint config, use that. Otherwise, use the one in this repo.
+$CONFIG=""
+if [[ ! -f "$REPO_ROOT/.github/actionlint.yml" ]] && [[ ! -f "$REPO_ROOT/.github/actionlint.yaml" ]]; then
+    CONFIG="-config-file $SCRIPT_DIR/../.github/actionlint.yml"
+fi
+
+if ! "$ACTIONLINT_PATH" -color "$CONFIG"; then
     error "Workflows did not pass actionlint :("
     exit 1
 fi

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -2,7 +2,7 @@
 #################################################################
 #    Lint workflows with https://github.com/rhysd/actionlint    #
 #################################################################
-set -x
+
 # Verify that shellcheck is installed (preinstalled on GitHub Actions runners)
 if ! command -v shellcheck &>/dev/null; then
     error "This script requires shellcheck. Please install it and try again"

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -123,10 +123,13 @@ cd "$REPO_ROOT" || exit 1
 # If a repo has it's own action lint config, use that. Otherwise, use the one in this repo.
 CONFIG=""
 if [[ ! -f "$REPO_ROOT/.github/actionlint.yml" ]] && [[ ! -f "$REPO_ROOT/.github/actionlint.yaml" ]]; then
-    CONFIG=" -config-file $(readlink -f $SCRIPT_DIR/../.github/actionlint.yml)"
+    CONFIG=" -config-file $(readlink -f "$SCRIPT_DIR"/../.github/actionlint.yml)"
     info "Using default Github-Actions repo actionlint.yml" >&2
 fi
 
+# We can't quote CONFIG here because we need the splitting on spaces for it to be recognized
+# by actionlint as a flag
+#shellcheck disable=SC2086
 if ! "$ACTIONLINT_PATH" ${CONFIG} -color; then
     error "Workflows did not pass actionlint :("
     exit 1


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@AndrewGable I think this will let us use the actionlint config in this repo instead of each remote repo if a remote repo doesn't have it's own config.


### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
On main in a repo with no actionlint.yml:
```
../GitHub-Actions/scripts/actionlint.sh

Lint Github Actions via actionlint (https://github.com/rhysd/actionlint)
Found actionlint version 1.7.7 already installed
Linting workflows...

.github/workflows/pytest.yml:14:14: label "blacksmith-4vcpu-2404" is unknown. available labels are "windows-latest", "windows-latest-8-cores", "windows-2025", "windows-2022", "windows-2019", "ubuntu-latest", "ubuntu-latest-4-cores", "ubuntu-latest-8-cores", "ubuntu-latest-16-cores", "ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-22.04", "ubuntu-22.04-arm", "ubuntu-20.04", "macos-latest", "macos-latest-xl", "macos-latest-xlarge", "macos-latest-large", "macos-15-xlarge", "macos-15-large", "macos-15", "macos-14-xl", "macos-14-xlarge", "macos-14-large", "macos-14", "macos-13-xl", "macos-13-xlarge", "macos-13-large", "macos-13", "self-hosted", "x64", "arm", "arm64", "linux", "macos", "windows". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]
   |
14 |     runs-on: blacksmith-4vcpu-2404
   |              ^~~~~~~~~~~~~~~~~~~~~
💥 Workflows did not pass actionlint :(
```

On this branch:
```
$ ../GitHub-Actions/scripts/actionlint.sh

Lint Github Actions via actionlint (https://github.com/rhysd/actionlint)
Found actionlint version 1.7.7 already installed
Linting workflows...
```

On this branch with a local actionlint:
```
$  ../GitHub-Actions/scripts/actionlint.sh

Lint Github Actions via actionlint (https://github.com/rhysd/actionlint)
Found actionlint version 1.7.7 already installed
Linting workflows...

🎉 Workflows passed actionlint!
```

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->