### PR TITLE
Add missing self-hosted runner labels to central actionlint config

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -9,6 +9,7 @@ self-hosted-runner:
     - macos-15-xlarge
     - macos-12
     - ubuntu-24.04-v4
+    - ubuntu-24.04-v64
     - blacksmith-2vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2404


### PR DESCRIPTION
### Details
Add the `ubuntu-24.04-v64` label to the central actionlint config. This label was previously only defined in per-repo actionlint config files across the org.

This is part of a consolidation effort to remove redundant per-repo `.github/actionlint.yml` files in favor of this central config. The blacksmith runner labels were already added in a recent commit to main.

### Related Issues
Related PRs removing per-repo actionlint configs:
- https://github.com/Expensify/App/pull/82689
- https://github.com/Expensify/Auth/pull/19964
- https://github.com/Expensify/Bedrock/pull/2516
- https://github.com/Expensify/Comp/pull/605
- https://github.com/Expensify/Expensify/pull/601165
- https://github.com/Expensify/Expensidev/pull/1046
- https://github.com/Expensify/ExpensifyBackupManager/pull/147
- https://github.com/Expensify/ExpensifyTableManager/pull/76
- https://github.com/Expensify/FuzzyBot/pull/334
- https://github.com/Expensify/Integration-Server/pull/8751
- https://github.com/Expensify/PHP-Libs/pull/1234
- https://github.com/Expensify/Web-Expensify/pull/50788
- https://github.com/Expensify/Web-PDFs/pull/627
- https://github.com/Expensify/Web-Secure/pull/2928
- https://github.com/Expensify/WhitelistDB/pull/31
- https://github.com/Expensify/react-native-onyx/pull/739
- https://github.com/Expensify/actions-images/pull/20

### Manual Tests
N/A - config change only. The actionlint check will validate this config is correct when CI runs.

### Linked PRs
See related issues above.

Made with [Cursor](https://cursor.com)