### PR TITLE
Add ARM architecture options for Ubuntu 24.04

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -20,6 +20,11 @@ self-hosted-runner:
     - blacksmith-8vcpu-windows-2025
     - blacksmith-16vcpu-windows-2025
     - blacksmith-32vcpu-windows-2025
+    - blacksmith-2vcpu-ubuntu-2404-arm
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-8vcpu-ubuntu-2404-arm
+    - blacksmith-16vcpu-ubuntu-2404-arm
+    - blacksmith-32vcpu-ubuntu-2404-arm
 
 paths:
   '**/*':


### PR DESCRIPTION
Adding the ARM runners as valid options from https://docs.blacksmith.sh/blacksmith-runners/overview