### PR TITLE
Upgrade node20 actions in setupGitForOSBotify to node24

### DIFF
--- a/setupGitForOSBotify/action.yml
+++ b/setupGitForOSBotify/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Install 1Password CLI
-      uses: 1password/install-cli-action@9a0c9dd934086b7ab1d90115d455bda1c53c2bdb
+      uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 # v3
 
     - name: Download OSBotify GPG key
       run: op read "op://${{ inputs.OP_VAULT }}/OSBotify-private-key.asc/OSBotify-private-key.asc" --force --out-file ./OSBotify-private-key.asc
@@ -64,7 +64,7 @@ runs:
     - name: Generate a token
       id: generateToken
       if: inputs.SETUP_AS_APP == 'true'
-      uses: actions/create-github-app-token@9d97a4282b2c51a2f4f0465b9326399f53c890d4
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
       with:
         app-id: ${{ inputs.OS_BOTIFY_APP_ID }}
         private-key: ${{ inputs.OS_BOTIFY_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Upgrades two actions in `setupGitForOSBotify/action.yml` that were still running on node20 (deprecated, forced to node24 starting June 2, 2026):

- `1password/install-cli-action`: `9a0c9dd` (node20) → `8d006a0d` (v3, node24)
- `actions/create-github-app-token`: `9d97a428` (v2, node20) → `f8d387b6` (v3, node24)

Note: `actions/create-github-app-token` v3 removed custom proxy handling. If `HTTP_PROXY`/`HTTPS_PROXY` is in use, `NODE_USE_ENV_PROXY=1` would need to be set — this doesn't apply to the OSBotify token generation use case here.

## Test plan
- [x] CI passes with the updated action versions

Made with [Cursor](https://cursor.com)