### PR TITLE
Add missing macOS blacksmith runner types

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -10,6 +10,8 @@ self-hosted-runner:
     - macos-12
     - ubuntu-24.04-v4
     - ubuntu-24.04-v64
+    - blacksmith-6vcpu-macos-latest
+    - blacksmith-12vcpu-macos-latest
     - blacksmith-2vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2404


### PR DESCRIPTION
### Details
New runners added: https://docs.blacksmith.sh/blacksmith-runners/overview#macos-runners

### Related Issues
n/a

### Manual Tests
n/a

### Linked PRs
https://github.com/Expensify/App/pull/88475