### PR TITLE
Use GitHub App token for CLA commits to satisfy signed commits policy

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.issue.pull_request || github.event_name == 'pull_request_target'
     steps:
       - name: Generate GitHub App token for CLA repo
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: &cla-step-condition "(github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'"
         id: generate-token
         # Version: 3.1.1
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
@@ -28,7 +28,7 @@ jobs:
           repositories: CLA
 
       - name: CLA Assistant
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: *cla-step-condition
         # Version: 2.6.1
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,13 +13,27 @@ jobs:
     # This job should only run for pull request comments or pull request target events (not issue comments)
     if: github.event.issue.pull_request || github.event_name == 'pull_request_target'
     steps:
+      - name: Generate GitHub App token for CLA repo
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        id: generate-token
+        # Version: 3.1.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          # GitHub App tokens are automatically signed by GitHub's web-flow GPG key,
+          # whereas PATs are not. This is required since the Expensify org enforces
+          # signed commits on all repositories (including Expensify/CLA).
+          client-id: ${{ secrets.CLA_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLA_GITHUB_APP_PRIVATE_KEY }}
+          owner: Expensify
+          repositories: CLA
+
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Version: 2.6.1
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_BOTIFY_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           path-to-signatures: '${{ github.repository }}/cla.json'
           path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'


### PR DESCRIPTION
### Problem

The CLA bot (CLABotify) was using a Personal Access Token (`CLA_BOTIFY_TOKEN`) to push commits to the [Expensify/CLA](https://github.com/Expensify/CLA) repository. When the Expensify org enabled the "Enforce signed commits" ruleset on 2026-04-09, this started failing — PAT-authenticated API commits are **not** automatically signed by GitHub.

### Solution

Replace the PAT with a **GitHub App installation token**. Commits made via the REST API with a GitHub App installation token are automatically signed by GitHub's `web-flow` GPG key — no GPG key management required.

This adds a new step before the CLA Assistant action that generates a scoped installation token (limited to the `Expensify/CLA` repository) using `actions/create-github-app-token@v3.1.1`.

### Required setup (before merging)

1. Create a GitHub App (or reuse an existing one) with `contents: write` permission, installed on `Expensify/CLA`
2. Add two org-level secrets (or secrets on each calling repo):
   - `CLA_GITHUB_APP_CLIENT_ID` — the App's client ID
   - `CLA_GITHUB_APP_PRIVATE_KEY` — the App's RSA private key (PEM format)

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/631744

### Tests

- [ ] Verify the workflow runs end-to-end after the GitHub App and secrets are configured (trigger by opening a test PR from an external contributor and having them sign the CLA)

### PR Author Checklist

- [x] I linked the correct issue in the `Fixed Issues` section above
- [x] I wrote clear testing steps for all QA scenarios
- [x] I added comments to the code to explain *why*, not *what* the code is doing
- [x] I confirmed my changes don't break any other existing functionality

Made with [Cursor](https://cursor.com)