### PR TITLE
Fix immutable action ref parser

### DIFF
--- a/scripts/validateImmutableActionRefs.sh
+++ b/scripts/validateImmutableActionRefs.sh
@@ -24,14 +24,14 @@ fi
 # - action metadata files, which can be anywhere in the repo, but must be called action.yml or action.yaml
 ACTIONS="$(find "$REPO_ROOT" -type f \( -name "action.yml" -o -name "action.yaml" \))"
 if [[ -z "$ACTIONS" ]]; then
-    warning "No workflows found. Did you remember to run this script from the root of a repository?" >&2
+    warning "No action metadata files found." >&2
 fi
 
 readonly YAML_FILES="$WORKFLOWS $ACTIONS"
 
 # Find yaml files in the `.github` directory
 for FILE in $YAML_FILES; do
-    USES_LINES="$(grep "uses:" "$FILE")"
+    USES_LINES="$(grep -E "^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+" "$FILE")"
 
     # Ignore files without external action usages
     if [[ -z "$USES_LINES" ]]; then

--- a/scripts/validateImmutableActionRefs.sh
+++ b/scripts/validateImmutableActionRefs.sh
@@ -24,7 +24,7 @@ fi
 # - action metadata files, which can be anywhere in the repo, but must be called action.yml or action.yaml
 ACTIONS="$(find "$REPO_ROOT" -type f \( -name "action.yml" -o -name "action.yaml" \))"
 if [[ -z "$ACTIONS" ]]; then
-    warning "No action metadata files found." >&2
+    warning "No workflows found. Did you remember to run this script from the root of a repository?" >&2
 fi
 
 readonly YAML_FILES="$WORKFLOWS $ACTIONS"


### PR DESCRIPTION
### Details
Fixes `validateImmutableActionRefs.sh` so it only parses actual YAML `uses:` keys. The previous `grep "uses:"` also matched keys like `permission-statuses: read`, causing the validator to treat `read` as an action reference and fail incorrectly.

### Related Issues
N/A

### Manual Tests
Run this from the `GitHub-Actions` repo root:

```bash
set -euo pipefail

FIXTURE_DIR=$(mktemp -d /tmp/immutable-action-refs.XXXXXX)
mkdir -p "$FIXTURE_DIR/.github/workflows"
cat > "$FIXTURE_DIR/.github/workflows/repro.yml" <<'YAML'
name: Repro
on: workflow_dispatch
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - name: Generate token
        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
        with:
          permission-statuses: read
YAML

old_usages=$(grep "uses:" "$FIXTURE_DIR/.github/workflows/repro.yml" | awk '{print $2}' | sort | uniq)
printf 'Old parser output:\n%s\n\n' "$old_usages"
printf '%s\n' "$old_usages" | grep -qx 'read'

REPO_ROOT="$FIXTURE_DIR" scripts/validateImmutableActionRefs.sh
scripts/shellCheck.sh
REPO_ROOT=/Users/andrew/Expensidev/melvin scripts/validateImmutableActionRefs.sh
```

Expected output from the old parser check includes the false-positive `read` action usage:

```text
Old parser output:
actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
read
```

Expected output from the fixed validator does not include `read` in `All action usages` and ends with:

```text
All untrusted actions are using immutable references
```

### Linked PRs
https://github.com/Expensify/melvin/pull/93