### PR TITLE
Document safe schema-extension pattern in claude-review-toolkit README

### DIFF
--- a/.github/actions/claude-review-toolkit/README.md
+++ b/.github/actions/claude-review-toolkit/README.md
@@ -48,15 +48,19 @@ Caller repos must ship a `.claude/skills/coding-standards/rules/` directory with
 
 ## Schema extension
 
-Repos that need extra fields on top of the canonical schema should `jq`-merge them in a follow-up step before feeding `claude_args`:
+Repos that need extra fields on top of the canonical schema should `jq`-merge them in a follow-up step before feeding `claude_args`. Read the canonical schema from `schema_path` (a file) rather than piping `schema_json` through `echo`, so the shell never sees the schema's `"` characters:
 
 ```yaml
 - name: Extend schema
   id: schema
+  env:
+    SCHEMA_PATH: ${{ steps.toolkit.outputs.schema_path }}
   run: |
-    EXTENDED=$(echo "${{ steps.toolkit.outputs.schema_json }}" \
-      | jq -c '.properties.missingQueryTimings = {"type":"boolean"} | .required += ["missingQueryTimings"]')
+    EXTENDED=$(jq -c '.properties.missingQueryTimings = {"type":"boolean"} | .required += ["missingQueryTimings"]' "$SCHEMA_PATH")
     echo "json=$EXTENDED" >> "$GITHUB_OUTPUT"
 ```
 
 Keep extensions narrow - the canonical schema stays the source of truth for the violations array shared across all reviewers.
+
+> [!WARNING]
+> Do **not** consume `schema_json` from a shell step via `echo "${{ steps.toolkit.outputs.schema_json }}"`. GitHub Actions interpolates the expression before bash parses the line, and the schema's inner `"` characters terminate the surrounding shell string - `jq` then sees mangled input and exits with a parse error. Use the `schema_path` form above for any `jq`/shell manipulation; reserve `schema_json` for the single-quoted `claude_args:` form shown in [Usage](#usage), where the action's argv parser handles it correctly.


### PR DESCRIPTION
### Details

The `claude-review-toolkit` README's "Schema extension" example recommends piping the `schema_json` step output through `echo "${{ ... }}" | jq ...`. That pattern is unsafe: GitHub Actions interpolates `${{ steps.toolkit.outputs.schema_json }}` *before* bash parses the line, and the schema's `"` characters terminate the surrounding shell double-quoted string. `jq` then receives mangled input (the quotes get stripped) and exits with `parse error: Invalid literal at line 1, column 6`. This is exactly what broke the `claude-review.yml` workflow in `Expensify/Auth` after it adopted the example verbatim (see `Expensify/Auth#21744` for the consumer-side fix).

This change is **docs-only**:

- Swap the "Schema extension" example to read `schema_path` (which the action already exposes) and pass it to `jq` directly. The schema travels through the filesystem instead of through GHA templating, so the quoting trap becomes structurally impossible.
- Route the file path through `env:` (`SCHEMA_PATH: ${{ steps.toolkit.outputs.schema_path }}` → `"$SCHEMA_PATH"`) so the example stays correct even if the path ever contains shell-special characters.
- Add a `> [!WARNING]` callout immediately after the example explaining why `echo "${{ ... }}"` of `schema_json` must be avoided, and clarifying that `schema_json` is still fine in the single-quoted `claude_args:` form shown in the Usage section (the action's argv parser handles it).

No `action.yml` change is required — `schema_path` is already an output of the composite action.

### Related Issues

N/A - follow-up to the Auth consumer-side fix.

### Manual Tests

N/A - documentation-only change; no executable code path is modified. Verified locally that the new example shape (`jq -c '...' "$SCHEMA_PATH"`) produces the same compacted JSON as the prior `echo … | jq -c '...'` pipeline when fed the canonical `schemas/code-review-output.json`.

### Linked PRs

N/A