### PR TITLE
Add postCodeReviewResults.sh to claude-review-toolkit

### DIFF
--- a/.github/actions/claude-review-toolkit/README.md
+++ b/.github/actions/claude-review-toolkit/README.md
@@ -44,6 +44,7 @@ Caller repos must ship a `.claude/skills/coding-standards/rules/` directory with
 | `addPrReaction.sh` | `<PR_NUMBER> <REACTION>` | Adds a reaction (`+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`) to the PR. |
 | `removePrReaction.sh` | `<PR_NUMBER> <REACTION> <USER>` | Removes the matching reaction authored by `<USER>` (typically `github-actions[bot]`). Idempotent. |
 | `createInlineComment.sh` | `<PR_NUMBER> <path> <body> <line>` | Posts an inline review comment. Requires `GITHUB_REPOSITORY`, `GH_TOKEN`, and `ALLOWED_RULES_FILE` in env. The body must reference a rule tag matching `[A-Z]+(-[A-Z]+)*-[0-9]+` (e.g. `PERF-1`) that is present in the allowlist; otherwise the comment is rejected. |
+| `postCodeReviewResults.sh` | `<PR_NUMBER>` | Posts the result of a Claude code review. With no violations, adds a `+1` reaction to the PR; with violations, posts one inline comment per violation. Reads the JSON output from env `STRUCTURED_OUTPUT`. Requires `GH_TOKEN`, `GITHUB_REPOSITORY`, and `ALLOWED_RULES_FILE` in env. Individual comment failures are swallowed so one rejected comment does not kill the loop. |
 | `extractAllowedRules.sh` | `<rules-dir> <output-file>` | Walks `<rules-dir>` for `.md` rule files and writes their `ruleId:` tags to `<output-file>`. Invoked automatically by the action; rarely called directly. |
 
 ## Schema extension

--- a/.github/actions/claude-review-toolkit/scripts/postCodeReviewResults.sh
+++ b/.github/actions/claude-review-toolkit/scripts/postCodeReviewResults.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Post the result of a Claude code review.
+# With no violations: adds a "+1" reaction to the PR.
+# With violations: posts one inline comment per violation parsed from $STRUCTURED_OUTPUT.
+# Usage: postCodeReviewResults.sh <PR_NUMBER>
+# Env: STRUCTURED_OUTPUT (JSON from claude-code-action), GH_TOKEN, GITHUB_REPOSITORY, ALLOWED_RULES_FILE
+set -eu
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <PR_NUMBER>" >&2
+    exit 1
+fi
+
+if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR_NUMBER must be a positive integer" >&2
+    exit 1
+fi
+
+if [[ -z "${STRUCTURED_OUTPUT:-}" ]]; then
+    echo "::error::Claude Code Action returned empty structured output" >&2
+    exit 1
+fi
+
+readonly PR_NUMBER="$1"
+
+COUNT=$(echo "$STRUCTURED_OUTPUT" | jq '.violations | length')
+readonly COUNT
+
+if [[ "$COUNT" -eq 0 ]]; then
+    addPrReaction.sh "$PR_NUMBER" "+1"
+else
+    echo "$STRUCTURED_OUTPUT" | jq -c '.violations[]' | while IFS= read -r violation; do
+        PATH_ARG=$(echo "$violation" | jq -r '.path')
+        BODY_ARG=$(echo "$violation" | jq -r '.body')
+        LINE_ARG=$(echo "$violation" | jq -r '.line')
+        createInlineComment.sh "$PR_NUMBER" "$PATH_ARG" "$BODY_ARG" "$LINE_ARG" || true
+    done
+fi


### PR DESCRIPTION
### Details

Adds a new helper script to the `claude-review-toolkit` composite action that centralises the violations post-processing loop currently duplicated across the three client `claude-review.yml` workflows (`Expensify/App`, `Expensify/Auth`, `Expensify/Web-Expensify`).

Behaviour preserved exactly:
- Reads `STRUCTURED_OUTPUT` from env, takes `PR_NUMBER` as positional arg
- 0 violations -> `addPrReaction.sh "$PR_NUMBER" "+1"`
- N violations -> N `createInlineComment.sh` calls (one per violation, individual failures swallowed with `|| true`)
- Empty/missing `STRUCTURED_OUTPUT` -> `::error::` annotation + exit 1
- Strict positional-arg validation (non-numeric `PR_NUMBER` rejected)

After this lands, the three client workflows can replace their inline `jq` + while-loop block with a single `postCodeReviewResults.sh "$PR_NUMBER"` call. The client adoption PRs follow this one.

This is slice 2 of the centralisation effort tracked in https://github.com/Expensify/Expensify/issues/635397.

### Related Issues

https://github.com/Expensify/Expensify/issues/635397

### Manual Tests

Smoke-tested locally with mocked `addPrReaction.sh` / `createInlineComment.sh` on `PATH`:
- 0 violations -> single `+1` reaction call
- 2 violations -> 2 inline-comment calls with correct path/body/line args
- Body containing backticks and embedded double-quotes -> preserved intact
- Empty `STRUCTURED_OUTPUT` -> `::error::` + exit 1
- Non-numeric `PR_NUMBER` -> error + exit 1
- Missing `PR_NUMBER` -> usage + exit 1

End-to-end exercise comes from the client adoption PRs (linked below) running on real PRs of this repo.

### Linked PRs

Client adoption PRs (drafts; reference this PR by placeholder SHA, re-stamped on merge):
- Expensify/App PR (forthcoming)
- Expensify/Auth PR (forthcoming)
- Expensify/Web-Expensify PR (forthcoming)