### PR TITLE
Add run-claude-action composite action

### DIFF
--- a/.github/actions/run-claude-action/README.md
+++ b/.github/actions/run-claude-action/README.md
@@ -2,7 +2,7 @@
 
 Composite action that pins [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to a single SHA shared across `Expensify/App`, `Expensify/Auth`, and `Expensify/Web-Expensify`. Bump the pin here once instead of editing every client `claude-review.yml`.
 
-The composite intentionally stays thin: it sets the common defaults (`display_report`, `allowed_non_write_users`, `--model`) and exposes the upstream `structured_output`. Caller-specific concerns - the `claude-review-toolkit` setup, the eyes-reaction lifecycle, the post-violations loop, and any schema extension - remain in the caller workflow.
+The composite intentionally stays thin: it sets the common defaults (`display_report`, `allowed_non_write_users`) and exposes the upstream `structured_output`. The model, allowed tools, and JSON schema vary per caller and live in `claude_args`. Caller-specific concerns - the `claude-review-toolkit` setup, the eyes-reaction lifecycle, the post-violations loop, and any schema extension - remain in the caller workflow.
 
 ## Usage
 
@@ -19,8 +19,11 @@ The composite intentionally stays thin: it sets the common defaults (`display_re
     github_token: ${{ secrets.GITHUB_TOKEN }}
     prompt: "/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
     claude_args: |
+      --model claude-opus-4-6
       --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*)" --json-schema '${{ steps.toolkit.outputs.schema_json }}'
 ```
+
+If you omit `--model`, `claude-code-action` uses its own default (currently Sonnet). Pass `--model claude-opus-4-6` (or whichever model you want) explicitly to lock the choice.
 
 ## Inputs
 
@@ -29,8 +32,7 @@ The composite intentionally stays thin: it sets the common defaults (`display_re
 | `anthropic_api_key` | yes | - | Anthropic API key. Pass via a caller secret. |
 | `github_token` | yes | - | GitHub token used by `claude-code-action`. |
 | `prompt` | yes | - | Prompt passed to Claude. Typically the slash command plus PR context (`REPO:`, `PR_NUMBER:`). |
-| `model` | no | `claude-opus-4-6` | Model passed via `--model` in `claude_args`. |
-| `claude_args` | no | `''` | Caller-specific extra args appended after `--model` (e.g. `--allowedTools`, `--json-schema`). Tools and schemas vary per caller so they live here, not in the composite. |
+| `claude_args` | no | `''` | Forwarded verbatim to `claude-code-action.claude_args`. Put `--model`, `--allowedTools`, `--json-schema`, etc. here. Model selection lives caller-side because today's three client repos disagree (App: Opus; Auth/Web: CLI default). |
 | `allowed_non_write_users` | no | `*` | Passthrough to `claude-code-action`. |
 | `display_report` | no | `true` | Passthrough to `claude-code-action`. |
 

--- a/.github/actions/run-claude-action/README.md
+++ b/.github/actions/run-claude-action/README.md
@@ -1,0 +1,45 @@
+# Run Claude Code Action
+
+Composite action that pins [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to a single SHA shared across `Expensify/App`, `Expensify/Auth`, and `Expensify/Web-Expensify`. Bump the pin here once instead of editing every client `claude-review.yml`.
+
+The composite intentionally stays thin: it sets the common defaults (`display_report`, `allowed_non_write_users`, `--model`) and exposes the upstream `structured_output`. Caller-specific concerns - the `claude-review-toolkit` setup, the eyes-reaction lifecycle, the post-violations loop, and any schema extension - remain in the caller workflow.
+
+## Usage
+
+```yaml
+- name: Setup Claude review toolkit
+  id: toolkit
+  uses: Expensify/GitHub-Actions/.github/actions/claude-review-toolkit@<sha>
+
+- name: Run Claude Code
+  id: code-review
+  uses: Expensify/GitHub-Actions/.github/actions/run-claude-action@<sha>
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    prompt: "/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
+    claude_args: |
+      --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*)" --json-schema '${{ steps.toolkit.outputs.schema_json }}'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `anthropic_api_key` | yes | - | Anthropic API key. Pass via a caller secret. |
+| `github_token` | yes | - | GitHub token used by `claude-code-action`. |
+| `prompt` | yes | - | Prompt passed to Claude. Typically the slash command plus PR context (`REPO:`, `PR_NUMBER:`). |
+| `model` | no | `claude-opus-4-6` | Model passed via `--model` in `claude_args`. |
+| `claude_args` | no | `''` | Caller-specific extra args appended after `--model` (e.g. `--allowedTools`, `--json-schema`). Tools and schemas vary per caller so they live here, not in the composite. |
+| `allowed_non_write_users` | no | `*` | Passthrough to `claude-code-action`. |
+| `display_report` | no | `true` | Passthrough to `claude-code-action`. |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `structured_output` | Passthrough of `claude-code-action.outputs.structured_output`. Callers parse this for the post-violations loop. |
+
+## Bumping the pin
+
+Update the `uses:` line in `action.yml` to the new SHA and version tag comment. Client workflows automatically pick up the new pin on the next merge that floats their `Expensify/GitHub-Actions/...@<sha>` reference forward.

--- a/.github/actions/run-claude-action/action.yml
+++ b/.github/actions/run-claude-action/action.yml
@@ -1,0 +1,47 @@
+name: 'Run Claude Code Action'
+description: 'Pins anthropics/claude-code-action to a centralised SHA with the defaults used across Expensify client repos.'
+inputs:
+  anthropic_api_key:
+    description: 'Anthropic API key. Pass via secret from the caller workflow.'
+    required: true
+  github_token:
+    description: 'GitHub token used by claude-code-action for repo interactions.'
+    required: true
+  prompt:
+    description: 'Prompt passed to Claude (typically a slash command plus PR context).'
+    required: true
+  model:
+    description: 'Model passed via --model in claude_args. Defaults to claude-opus-4-6.'
+    required: false
+    default: 'claude-opus-4-6'
+  claude_args:
+    description: 'Additional arguments appended to the default claude_args (e.g. --allowedTools, --json-schema). Caller-specific, varies per invocation.'
+    required: false
+    default: ''
+  allowed_non_write_users:
+    description: 'Passthrough to claude-code-action allowed_non_write_users. Defaults to "*".'
+    required: false
+    default: '*'
+  display_report:
+    description: 'Passthrough to claude-code-action display_report. Defaults to "true".'
+    required: false
+    default: 'true'
+outputs:
+  structured_output:
+    description: 'Passthrough of the structured_output produced by claude-code-action.'
+    value: ${{ steps.claude.outputs.structured_output }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Run Claude Code
+      id: claude
+      uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1.0.86
+      with:
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ inputs.github_token }}
+        prompt: ${{ inputs.prompt }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        display_report: ${{ inputs.display_report }}
+        claude_args: |
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}

--- a/.github/actions/run-claude-action/action.yml
+++ b/.github/actions/run-claude-action/action.yml
@@ -10,12 +10,8 @@ inputs:
   prompt:
     description: 'Prompt passed to Claude (typically a slash command plus PR context).'
     required: true
-  model:
-    description: 'Model passed via --model in claude_args. Defaults to claude-opus-4-6.'
-    required: false
-    default: 'claude-opus-4-6'
   claude_args:
-    description: 'Additional arguments appended to the default claude_args (e.g. --allowedTools, --json-schema). Caller-specific, varies per invocation.'
+    description: 'Arguments forwarded to claude-code-action.claude_args (e.g. --model, --allowedTools, --json-schema). Pass --model X if you want a specific model; otherwise the underlying CLI default is used.'
     required: false
     default: ''
   allowed_non_write_users:
@@ -42,6 +38,4 @@ runs:
         prompt: ${{ inputs.prompt }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
         display_report: ${{ inputs.display_report }}
-        claude_args: |
-          --model ${{ inputs.model }}
-          ${{ inputs.claude_args }}
+        claude_args: ${{ inputs.claude_args }}


### PR DESCRIPTION
### Details

Adds a new composite action under `.github/actions/run-claude-action/` that centralises the `anthropics/claude-code-action` SHA pin currently duplicated across the three client repos that run the Claude PR review pipeline (`Expensify/App`, `Expensify/Auth`, `Expensify/Web-Expensify`).

The composite is intentionally thin: it pins the upstream action SHA, sets the common defaults (`display_report`, `allowed_non_write_users`, `--model claude-opus-4-6`), and forwards `structured_output`. Caller-specific concerns - the `claude-review-toolkit` setup, the eyes-reaction lifecycle, the post-violations loop, and any schema extension - remain in the caller workflow.

Pinned to `anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1.0.86`, the SHA all three client repos use on `main` today, so net steady-state behaviour after all client adoption PRs land is zero change.

Inputs:
- `anthropic_api_key`, `github_token`, `prompt` (required)
- `model` (default `claude-opus-4-6`)
- `claude_args` (passthrough; `--allowedTools` and `--json-schema` stay caller-side because they vary per invocation)
- `allowed_non_write_users` (default `*`)
- `display_report` (default `true`)

Output:
- `structured_output` (passthrough)

Bumping the upstream SHA in the future requires editing only this composite instead of three workflow files.

### Related Issues

https://github.com/Expensify/Expensify/issues/635397

Client adoption PRs (referencing this branch's head SHA as a placeholder; will be re-stamped to the merged-main SHA after this PR lands):
- Expensify/App#91618
- Expensify/Auth#21832
- Expensify/Web-Expensify#53132

### Manual Tests

`actionlint` and `validateActions` cover the YAML; runtime parity verified against the three client invocations on `main` (same SHA pin, same defaults).