### PR TITLE
Add postCodeReviewResults.sh to claude-review-toolkit

### DIFF
--- a/.github/actions/claude-review-toolkit/README.md
+++ b/.github/actions/claude-review-toolkit/README.md
@@ -44,6 +44,7 @@ Caller repos must ship a `.claude/skills/coding-standards/rules/` directory with
 | `addPrReaction.sh` | `<PR_NUMBER> <REACTION>` | Adds a reaction (`+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`) to the PR. |
 | `removePrReaction.sh` | `<PR_NUMBER> <REACTION> <USER>` | Removes the matching reaction authored by `<USER>` (typically `github-actions[bot]`). Idempotent. |
 | `createInlineComment.sh` | `<PR_NUMBER> <path> <body> <line>` | Posts an inline review comment. Requires `GITHUB_REPOSITORY`, `GH_TOKEN`, and `ALLOWED_RULES_FILE` in env. The body must reference a rule tag matching `[A-Z]+(-[A-Z]+)*-[0-9]+` (e.g. `PERF-1`) that is present in the allowlist; otherwise the comment is rejected. |
+| `postCodeReviewResults.sh` | `<PR_NUMBER>` | Posts the result of a Claude code review. With no violations, adds a `+1` reaction to the PR; with violations, posts one inline comment per violation. Reads the JSON output from env `STRUCTURED_OUTPUT`. Requires `GH_TOKEN`, `GITHUB_REPOSITORY`, `ALLOWED_RULES_FILE`, and `STRUCTURED_OUTPUT` in env. Individual comment failures are swallowed so one rejected comment does not kill the loop. |
 | `extractAllowedRules.sh` | `<rules-dir> <output-file>` | Walks `<rules-dir>` for `.md` rule files and writes their `ruleId:` tags to `<output-file>`. Invoked automatically by the action; rarely called directly. |
 
 ## Schema extension

--- a/.github/actions/claude-review-toolkit/scripts/postCodeReviewResults.sh
+++ b/.github/actions/claude-review-toolkit/scripts/postCodeReviewResults.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Post the result of a Claude code review.
+# With no violations: adds a "+1" reaction to the PR.
+# With violations: posts one inline comment per violation parsed from $STRUCTURED_OUTPUT.
+# Usage: postCodeReviewResults.sh <PR_NUMBER>
+# Env: STRUCTURED_OUTPUT (JSON from claude-code-action), GH_TOKEN, GITHUB_REPOSITORY, ALLOWED_RULES_FILE
+set -eu
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <PR_NUMBER>" >&2
+    exit 1
+fi
+
+if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR_NUMBER must be a positive integer" >&2
+    exit 1
+fi
+
+if [[ -z "${STRUCTURED_OUTPUT:-}" ]]; then
+    echo "::error::Claude Code Action returned empty structured output" >&2
+    exit 1
+fi
+
+readonly PR_NUMBER="$1"
+
+COUNT=$(echo "$STRUCTURED_OUTPUT" | jq '.violations | length')
+readonly COUNT
+
+if [[ "$COUNT" -eq 0 ]]; then
+    addPrReaction.sh "$PR_NUMBER" "+1"
+else
+    echo "$STRUCTURED_OUTPUT" | jq -c '.violations[]' | while IFS= read -r violation; do
+        PATH_ARG=$(echo "$violation" | jq -r '.path')
+        BODY_ARG=$(echo "$violation" | jq -r '.body')
+        LINE_ARG=$(echo "$violation" | jq -r '.line')
+        createInlineComment.sh "$PR_NUMBER" "$PATH_ARG" "$BODY_ARG" "$LINE_ARG" || true
+    done
+fi


### PR DESCRIPTION
## Why
The "post review results" step - count violations, add a `+1` reaction when the review is clean, otherwise post one inline comment per violation - is currently copy-pasted verbatim into the `claude-review.yml` of every client repo (App, Auth, Web-Expensify). It is pure boilerplate and the only meaningful logic in those workflows that the shared `claude-review-toolkit` does not yet own.

## What
- Adds `postCodeReviewResults.sh` to the `claude-review-toolkit` composite action's `scripts/` directory (already placed on `PATH` by the action). It reads the review JSON from `$STRUCTURED_OUTPUT` and reuses the toolkit's existing `addPrReaction.sh` / `createInlineComment.sh`. Individual comment failures are swallowed so one rejected comment does not kill the loop.
- Documents the script in the toolkit `README.md` scripts table.

Usage: `postCodeReviewResults.sh <PR_NUMBER>` with `STRUCTURED_OUTPUT`, `GH_TOKEN`, `GITHUB_REPOSITORY`, and `ALLOWED_RULES_FILE` in env.

## Scope
Intentionally limited to the `postCodeReviewResults.sh` hoist only - no other changes.

## Client adoption
- Expensify/App#91689
- Expensify/Auth#21857
- Expensify/Web-Expensify#53157
