### PR TITLE
Add centralized setup-php-cache composite action

### DIFF
--- a/setup-php-cache/README.md
+++ b/setup-php-cache/README.md
@@ -4,19 +4,29 @@ Composite action that restores keyed GitHub Actions caches used by PHP CI workfl
 
 Caches bin, `.cache`, apt archives, and GPG dirs (with chmod prep for system paths).
 
+## Inputs
+
+| Input          | Required | Description                                              |
+| -------------- | -------- | -------------------------------------------------------- |
+| `php-version`  | Yes      | PHP version used by the consumer workflow (e.g. `8.3.31`) |
+
+Pass the same version you use with `shivammathur/setup-php` so version-specific system paths are chmod'd only when they exist.
+
 ## Usage
 
 ```yml
 - name: Setup Cache
   uses: Expensify/GitHub-Actions/setup-php-cache@main
+  with:
+    php-version: 8.3.31
 ```
 
 ## Cache keys
 
 Caches are keyed by runner OS and UTC date (`YYYYmmdd`), with restore keys that fall back to the most recent cache for that OS.
 
-| Cache        | Paths                                            |
-| ------------ | ------------------------------------------------ |
-| Binary       | `_tools/ci/bin`                                  |
-| Project      | `.cache`, `/var/cache/apt/archives`              |
-| GPG keys     | `/etc/apt/trusted.gpg.d`, `/etc/apt/trusted.gpg` |
+| Cache    | Paths                                            |
+| -------- | ------------------------------------------------ |
+| Binary   | `_tools/ci/bin`                                  |
+| Project  | `.cache`, `/var/cache/apt/archives`              |
+| GPG keys | `/etc/apt/trusted.gpg.d`, `/etc/apt/trusted.gpg` |

--- a/setup-php-cache/README.md
+++ b/setup-php-cache/README.md
@@ -1,0 +1,40 @@
+# setup-php-cache
+
+Composite action that restores keyed GitHub Actions caches used by PHP CI workflows.
+
+## Inputs
+
+| Input     | Required | Default | Description                                                                                                     |
+| --------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `variant` | No       | `full`  | `full` caches bin, `.cache`, apt archives, and GPG dirs (with chmod prep). `lite` caches bin and `.cache` only. |
+
+## Usage
+
+### Web-Expensify (`full`)
+
+```yml
+- name: Setup Cache
+  uses: Expensify/GitHub-Actions/setup-php-cache@main
+  with:
+    variant: full
+```
+
+### Web-Secure (`lite`)
+
+```yml
+- name: Setup Cache
+  uses: Expensify/GitHub-Actions/setup-php-cache@main
+  with:
+    variant: lite
+```
+
+## Cache keys
+
+Caches are keyed by runner OS and UTC date (`YYYYmmdd`), with restore keys that fall back to the most recent cache for that OS.
+
+| Cache        | Paths                                            | Variant        |
+| ------------ | ------------------------------------------------ | -------------- |
+| Binary       | `_tools/ci/bin`                                  | `full`, `lite` |
+| Project      | `.cache`                                         | `full`, `lite` |
+| Apt archives | `/var/cache/apt/archives`                        | `full`         |
+| GPG keys     | `/etc/apt/trusted.gpg.d`, `/etc/apt/trusted.gpg` | `full`         |

--- a/setup-php-cache/README.md
+++ b/setup-php-cache/README.md
@@ -2,39 +2,21 @@
 
 Composite action that restores keyed GitHub Actions caches used by PHP CI workflows.
 
-## Inputs
-
-| Input     | Required | Default | Description                                                                                                     |
-| --------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `variant` | No       | `full`  | `full` caches bin, `.cache`, apt archives, and GPG dirs (with chmod prep). `lite` caches bin and `.cache` only. |
+Caches bin, `.cache`, apt archives, and GPG dirs (with chmod prep for system paths).
 
 ## Usage
 
-### Web-Expensify (`full`)
-
 ```yml
 - name: Setup Cache
   uses: Expensify/GitHub-Actions/setup-php-cache@main
-  with:
-    variant: full
-```
-
-### Web-Secure (`lite`)
-
-```yml
-- name: Setup Cache
-  uses: Expensify/GitHub-Actions/setup-php-cache@main
-  with:
-    variant: lite
 ```
 
 ## Cache keys
 
 Caches are keyed by runner OS and UTC date (`YYYYmmdd`), with restore keys that fall back to the most recent cache for that OS.
 
-| Cache        | Paths                                            | Variant        |
-| ------------ | ------------------------------------------------ | -------------- |
-| Binary       | `_tools/ci/bin`                                  | `full`, `lite` |
-| Project      | `.cache`                                         | `full`, `lite` |
-| Apt archives | `/var/cache/apt/archives`                        | `full`         |
-| GPG keys     | `/etc/apt/trusted.gpg.d`, `/etc/apt/trusted.gpg` | `full`         |
+| Cache        | Paths                                            |
+| ------------ | ------------------------------------------------ |
+| Binary       | `_tools/ci/bin`                                  |
+| Project      | `.cache`, `/var/cache/apt/archives`              |
+| GPG keys     | `/etc/apt/trusted.gpg.d`, `/etc/apt/trusted.gpg` |

--- a/setup-php-cache/README.md
+++ b/setup-php-cache/README.md
@@ -23,7 +23,7 @@ Pass the same version you use with `shivammathur/setup-php` so version-specific 
 
 ## Cache keys
 
-Caches are keyed by runner OS and UTC date (`YYYYmmdd`), with restore keys that fall back to the most recent cache for that OS.
+Caches are keyed by runner OS, architecture, and UTC date (`YYYYmmdd`), with restore keys that fall back to the most recent cache for that OS and architecture.
 
 | Cache    | Paths                                            |
 | -------- | ------------------------------------------------ |

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -29,7 +29,7 @@ runs:
       with:
         path: |-
           _tools/ci/bin
-        key: "${{ runner.os }}-bin-${{ steps.get-date.outputs.date }}"
+        key: '${{ runner.os }}-bin-${{ steps.get-date.outputs.date }}'
         restore-keys: |
           ${{ runner.os }}-bin-
 
@@ -40,7 +40,7 @@ runs:
         path: |-
           .cache
           /var/cache/apt/archives
-        key: "${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}"
+        key: '${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}'
         restore-keys: |
           ${{ runner.os }}-cache-
 
@@ -51,6 +51,6 @@ runs:
         path: |-
           /etc/apt/trusted.gpg.d
           /etc/apt/trusted.gpg
-        key: "${{ runner.os }}-keyserver-${{ steps.get-date.outputs.date }}"
+        key: '${{ runner.os }}-keyserver-${{ steps.get-date.outputs.date }}'
         restore-keys: |
           ${{ runner.os }}-keyserver-

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -1,12 +1,6 @@
 name: Set up PHP cache
 description: Set up keyed caches for PHP CI runners
 
-inputs:
-  variant:
-    description: "Cache variant: full (bin, .cache, apt archives, gpg dirs, chmod) or lite (bin, .cache only)"
-    required: false
-    default: full
-
 runs:
   using: composite
   steps:
@@ -19,7 +13,6 @@ runs:
     # Note this is important since system directories are root-owned, and the caching does not have root access.
     # This must run before any cache step that restores into a system directory.
     - name: Ensure permissions on system dirs and tar are all correct
-      if: ${{ case(inputs.variant, 'full', true, false) }}
       run: |
         sudo chmod 777 -R /etc/apt/trusted.gpg.d
         sudo chmod 777 /etc/apt/trusted.gpg || true
@@ -40,18 +33,18 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bin-
 
-    - name: ${{ case(inputs.variant, 'full', 'Set up .cache and apt package archives', 'Set up .cache') }}
+    - name: Set up .cache and apt package archives
       # v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
-        path: ${{ case(inputs.variant, 'full', '.cache
-/var/cache/apt/archives', '.cache') }}
+        path: |-
+          .cache
+          /var/cache/apt/archives
         key: "${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}"
         restore-keys: |
           ${{ runner.os }}-cache-
 
     - name: Set up apt-mirror cache for ubuntu gpg keys
-      if: ${{ case(inputs.variant, 'full', true, false) }}
       # v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -1,6 +1,11 @@
 name: Set up PHP cache
 description: Set up keyed caches for PHP CI runners
 
+inputs:
+  php-version:
+    description: PHP version used by the consumer workflow (for example 8.3.31)
+    required: true
+
 runs:
   using: composite
   steps:
@@ -14,12 +19,42 @@ runs:
     # This must run before any cache step that restores into a system directory.
     - name: Ensure permissions on system dirs and tar are all correct
       run: |
-        sudo chmod 777 -R /etc/apt/trusted.gpg.d
-        sudo chmod 777 /etc/apt/trusted.gpg || true
-        sudo chmod 777 /var/cache/apt/archives
-        sudo chmod 777 /usr/lib/php/20230831
-        sudo chmod 777 /etc/php/8.3/mods-available
-        sudo chmod 777 /etc/php/8.3/cli/conf.d
+        PHP_VERSION='${{ inputs.php-version }}'
+        PHP_MAJOR_MINOR="$(echo "$PHP_VERSION" | cut -d. -f1,2)"
+
+        case "$PHP_MAJOR_MINOR" in
+          8.1) PHP_ABI=20210902 ;;
+          8.2) PHP_ABI=20220829 ;;
+          8.3) PHP_ABI=20230831 ;;
+          8.4) PHP_ABI=20240924 ;;
+          8.5) PHP_ABI=20250925 ;;
+          *)
+            echo "Unsupported php-version for setup-php-cache: $PHP_VERSION"
+            exit 1
+            ;;
+        esac
+
+        chmod_path_if_exists() {
+          local path="$1"
+          local recursive="${2:-false}"
+
+          if [ ! -e "$path" ]; then
+            return 0
+          fi
+
+          if [ "$recursive" = "true" ]; then
+            sudo chmod 777 -R "$path"
+          else
+            sudo chmod 777 "$path"
+          fi
+        }
+
+        chmod_path_if_exists /etc/apt/trusted.gpg.d true
+        chmod_path_if_exists /etc/apt/trusted.gpg false
+        chmod_path_if_exists /var/cache/apt/archives false
+        chmod_path_if_exists "/usr/lib/php/$PHP_ABI" false
+        chmod_path_if_exists "/etc/php/$PHP_MAJOR_MINOR/mods-available" false
+        chmod_path_if_exists "/etc/php/$PHP_MAJOR_MINOR/cli/conf.d" false
         sudo chown root /bin/tar && sudo chmod u+s /bin/tar
       shell: bash
 

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -64,9 +64,9 @@ runs:
       with:
         path: |-
           _tools/ci/bin
-        key: '${{ runner.os }}-bin-${{ steps.get-date.outputs.date }}'
+        key: '${{ runner.os }}-${{ runner.arch }}-bin-${{ steps.get-date.outputs.date }}'
         restore-keys: |
-          ${{ runner.os }}-bin-
+          ${{ runner.os }}-${{ runner.arch }}-bin-
 
     - name: Set up .cache and apt package archives
       # v6.1.0
@@ -75,9 +75,9 @@ runs:
         path: |-
           .cache
           /var/cache/apt/archives
-        key: '${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}'
+        key: '${{ runner.os }}-${{ runner.arch }}-cache-${{ steps.get-date.outputs.date }}'
         restore-keys: |
-          ${{ runner.os }}-cache-
+          ${{ runner.os }}-${{ runner.arch }}-cache-
 
     - name: Set up apt-mirror cache for ubuntu gpg keys
       # v6.1.0

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -31,8 +31,8 @@ runs:
       shell: bash
 
     - name: Set up binary cache
-      # v4.2.0
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |-
           _tools/ci/bin
@@ -42,8 +42,8 @@ runs:
 
     - name: Set up .cache and apt package archives
       if: inputs.variant == 'full'
-      # v4.2.0
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |-
           .cache
@@ -54,8 +54,8 @@ runs:
 
     - name: Set up .cache
       if: inputs.variant == 'lite'
-      # v4.2.0
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |-
           .cache
@@ -65,8 +65,8 @@ runs:
 
     - name: Set up apt-mirror cache for ubuntu gpg keys
       if: inputs.variant == 'full'
-      # v4.2.0
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |-
           /etc/apt/trusted.gpg.d

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -1,0 +1,76 @@
+name: Set up PHP cache
+description: Set up keyed caches for PHP CI runners
+
+inputs:
+  variant:
+    description: "Cache variant: full (bin, .cache, apt archives, gpg dirs, chmod) or lite (bin, .cache only)"
+    required: false
+    default: full
+
+runs:
+  using: composite
+  steps:
+    - name: Get Date for cache keying
+      id: get-date
+      run: |
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Note this is important since system directories are root-owned, and the caching does not have root access.
+    # This must run before any cache step that restores into a system directory.
+    - name: Ensure permissions on system dirs and tar are all correct
+      if: inputs.variant == 'full'
+      run: |
+        sudo chmod 777 -R /etc/apt/trusted.gpg.d
+        sudo chmod 777 /etc/apt/trusted.gpg || true
+        sudo chmod 777 /var/cache/apt/archives
+        sudo chmod 777 /usr/lib/php/20230831
+        sudo chmod 777 /etc/php/8.3/mods-available
+        sudo chmod 777 /etc/php/8.3/cli/conf.d
+        sudo chown root /bin/tar && sudo chmod u+s /bin/tar
+      shell: bash
+
+    - name: Set up binary cache
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: |-
+          _tools/ci/bin
+        key: "${{ runner.os }}-bin-${{ steps.get-date.outputs.date }}"
+        restore-keys: |
+          ${{ runner.os }}-bin-
+
+    - name: Set up .cache and apt package archives
+      if: inputs.variant == 'full'
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: |-
+          .cache
+          /var/cache/apt/archives
+        key: "${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}"
+        restore-keys: |
+          ${{ runner.os }}-cache-
+
+    - name: Set up .cache
+      if: inputs.variant == 'lite'
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: |-
+          .cache
+        key: "${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}"
+        restore-keys: |
+          ${{ runner.os }}-cache-
+
+    - name: Set up apt-mirror cache for ubuntu gpg keys
+      if: inputs.variant == 'full'
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: |-
+          /etc/apt/trusted.gpg.d
+          /etc/apt/trusted.gpg
+        key: "${{ runner.os }}-keyserver-${{ steps.get-date.outputs.date }}"
+        restore-keys: |
+          ${{ runner.os }}-keyserver-

--- a/setup-php-cache/action.yml
+++ b/setup-php-cache/action.yml
@@ -19,7 +19,7 @@ runs:
     # Note this is important since system directories are root-owned, and the caching does not have root access.
     # This must run before any cache step that restores into a system directory.
     - name: Ensure permissions on system dirs and tar are all correct
-      if: inputs.variant == 'full'
+      if: ${{ case(inputs.variant, 'full', true, false) }}
       run: |
         sudo chmod 777 -R /etc/apt/trusted.gpg.d
         sudo chmod 777 /etc/apt/trusted.gpg || true
@@ -40,31 +40,18 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bin-
 
-    - name: Set up .cache and apt package archives
-      if: inputs.variant == 'full'
+    - name: ${{ case(inputs.variant, 'full', 'Set up .cache and apt package archives', 'Set up .cache') }}
       # v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
-        path: |-
-          .cache
-          /var/cache/apt/archives
-        key: "${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}"
-        restore-keys: |
-          ${{ runner.os }}-cache-
-
-    - name: Set up .cache
-      if: inputs.variant == 'lite'
-      # v6.1.0
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-      with:
-        path: |-
-          .cache
+        path: ${{ case(inputs.variant, 'full', '.cache
+/var/cache/apt/archives', '.cache') }}
         key: "${{ runner.os }}-cache-${{ steps.get-date.outputs.date }}"
         restore-keys: |
           ${{ runner.os }}-cache-
 
     - name: Set up apt-mirror cache for ubuntu gpg keys
-      if: inputs.variant == 'full'
+      if: ${{ case(inputs.variant, 'full', true, false) }}
       # v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:


### PR DESCRIPTION
## Summary
- Add `setup-php-cache` composite action for PHP CI runners
- Restores bin, `.cache`, apt archives, and GPG key caches (with chmod prep for system paths)
- Uses `actions/cache@v6.1.0` (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`)

## Test plan
CI only, tested in:

- https://github.com/Expensify/Web-Expensify/pull/53845
- https://github.com/Expensify/Web-Secure/pull/2978
