### PR TITLE
Add centralized setup-composer-cache action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Expensify Shared GitHub Actions workflows 🔄 
+# Expensify Shared GitHub Actions workflows 🔄
 
 ## What is the repository used for?
 
@@ -18,7 +18,7 @@ jobs:
     with:
       # Repository name with owner. For example, Expensify/eslint-config-expensify
       # Required, String, default: ${{ github.repository }}
-      repository: ''
+      repository: ""
 
       # True if we should run npm run build for the package
       # Optional, Boolean, default: false
@@ -37,13 +37,26 @@ jobs:
     secrets: inherit
 ```
 
+### `setup-composer-cache`
+
+Restores Composer download caches and optionally runs `composer install`. See [setup-composer-cache/README.md](./setup-composer-cache/README.md) for details.
+
+```yml
+- name: Setup Composer Cache
+  uses: Expensify/GitHub-Actions/setup-composer-cache@main
+  with:
+    run_install: true
+    dev: false
+```
+
 ## Rulesets
+
 GitHub [org-level rulesets](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-workflows-to-pass-before-merging) can be configured to run a workflow check against pull requests in all repos in the org. This is a very powerful feature, but there are some caveats and best practices to be aware of when enabling a ruleset.
 
 - Supported Event Triggers are documented [here](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#supported-event-triggers). However:
-    - When a workflow runs in response to a ruleset, some configs such as `branches`, `paths`, `paths-ignore`, that would normally be valid in a workflow are ignored.
-    - The default activity types for each event will be used. This means that something like `pull_request:comment` will not work - the `pull_request` event will always be triggered for the default activity types listed in the documentation.
-    - If you need to target or exclude specific branches, that can be configured in the ruleset settings.
-    - If you need to target or exclude specific paths, that must be implemented manually in the workflow itself.
+  - When a workflow runs in response to a ruleset, some configs such as `branches`, `paths`, `paths-ignore`, that would normally be valid in a workflow are ignored.
+  - The default activity types for each event will be used. This means that something like `pull_request:comment` will not work - the `pull_request` event will always be triggered for the default activity types listed in the documentation.
+  - If you need to target or exclude specific branches, that can be configured in the ruleset settings.
+  - If you need to target or exclude specific paths, that must be implemented manually in the workflow itself.
 - Due to a GitHub :bug:, PRs that are open when the rule is enabled will get stuck with a pending check that will never get picked up. The easiest way to fix that is to close and reopen the PR. Consider writing a script to close and reopen all open PRs across the org after the check is enabled.
 - It is less disruptive to [configure the ruleset to `Evaluate` first](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#using-evaluate-mode-for-ruleset-workflows), then `Active` once the kinks are worked out.

--- a/setup-composer-cache/README.md
+++ b/setup-composer-cache/README.md
@@ -1,0 +1,41 @@
+# setup-composer-cache
+
+Composite action that restores Composer download caches and optionally installs dependencies.
+
+## Inputs
+
+| Input               | Required | Default | Description                                                                 |
+| ------------------- | -------- | ------- | --------------------------------------------------------------------------- |
+| `working_directory` | No       | `.`     | Directory containing `composer.json` and `composer.lock`.                   |
+| `dev`               | No       | `false` | When `run_install` is true, pass `--dev` instead of `--no-dev` to Composer. |
+| `run_install`       | No       | `false` | Run `composer install` after restoring caches.                              |
+
+## Usage
+
+### Cache only (Auth)
+
+```yml
+- name: Setup Composer Cache
+  uses: Expensify/GitHub-Actions/setup-composer-cache@main
+  with:
+    working_directory: Web-Expensify
+```
+
+### Cache and install (Web-Expensify / Web-Secure / PHP-Libs)
+
+```yml
+- name: Setup Composer Cache
+  uses: Expensify/GitHub-Actions/setup-composer-cache@main
+  with:
+    run_install: true
+    dev: true
+```
+
+## Cache keys
+
+| Cache             | Paths                        | When                |
+| ----------------- | ---------------------------- | ------------------- |
+| Composer download | Composer `cache-files-dir`   | Always              |
+| Vendor            | `{working_directory}/vendor` | `run_install: true` |
+
+Composer download caches are keyed by runner OS, dev/prod variant, and `composer.lock` hash, with restore keys that fall back to the most recent cache for that OS and variant. Vendor caches use an exact key only (no restore keys) so a tree built from a different lock file is never reused.

--- a/setup-composer-cache/action.yml
+++ b/setup-composer-cache/action.yml
@@ -1,0 +1,53 @@
+name: Set up Composer Cache
+description: Set up Composer download cache and optionally install dependencies
+
+inputs:
+  working_directory:
+    description: Directory containing composer.json and composer.lock
+    required: false
+    default: "."
+  dev:
+    description: Install dev packages when run_install is true
+    required: false
+    default: "false"
+  run_install:
+    description: Run composer install after restoring caches
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(cd ${{ inputs.working_directory }} && composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Composer's global download cache (zipped dist files). Keyed by composer.lock with
+    # restore-keys fallbacks so that when the lock changes (vendor cache below misses), we
+    # still warm-start from a previous run and only download the changed packages.
+    - name: Cache Composer Files
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ inputs.dev == 'true' && 'dev' || 'prod' }}-${{ hashFiles(inputs.working_directory == '.' && 'composer.lock' || format('{0}/composer.lock', inputs.working_directory)) }}
+        restore-keys: |
+          ${{ runner.os }}-composer-${{ inputs.dev == 'true' && 'dev' || 'prod' }}-
+          ${{ runner.os }}-composer-
+
+    # The installed vendor directory. Exact key only (no restore-keys) so a vendor built from
+    # a different composer.lock is never reused. On a hit, the composer install below is a
+    # near-instant no-op; on a miss it rebuilds vendor from the download cache above.
+    - name: Cache vendor directory
+      if: inputs.run_install == 'true'
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: ${{ inputs.working_directory }}/vendor
+        key: ${{ runner.os }}-vendor-${{ inputs.dev == 'true' && 'dev' || 'prod' }}-${{ hashFiles(inputs.working_directory == '.' && 'composer.lock' || format('{0}/composer.lock', inputs.working_directory)) }}
+
+    - name: Composer install
+      if: inputs.run_install == 'true'
+      run: cd ${{ inputs.working_directory }} && composer install --prefer-dist --no-interaction ${{ inputs.dev == 'true' && '--dev' || '--no-dev'}}
+      shell: bash

--- a/setup-composer-cache/action.yml
+++ b/setup-composer-cache/action.yml
@@ -27,8 +27,8 @@ runs:
     # restore-keys fallbacks so that when the lock changes (vendor cache below misses), we
     # still warm-start from a previous run and only download the changed packages.
     - name: Cache Composer Files
-      # v4.2.0
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ inputs.dev == 'true' && 'dev' || 'prod' }}-${{ hashFiles(inputs.working_directory == '.' && 'composer.lock' || format('{0}/composer.lock', inputs.working_directory)) }}
@@ -41,8 +41,8 @@ runs:
     # near-instant no-op; on a miss it rebuilds vendor from the download cache above.
     - name: Cache vendor directory
       if: inputs.run_install == 'true'
-      # v4.2.0
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: ${{ inputs.working_directory }}/vendor
         key: ${{ runner.os }}-vendor-${{ inputs.dev == 'true' && 'dev' || 'prod' }}-${{ hashFiles(inputs.working_directory == '.' && 'composer.lock' || format('{0}/composer.lock', inputs.working_directory)) }}


### PR DESCRIPTION
### Details

Centralizes the duplicated `setup-composer-cache` composite action from Auth, Web-Expensify, Web-Secure, and PHP-Libs into GitHub-Actions.

Adds `setup-composer-cache` with inputs:
- `working_directory` (default `.`)
- `dev` (default `false`)
- `run_install` (default `false`)

### Related Issues

N/A — GitHub Actions centralization plan

### Manual Tests

No automated tests added. Consumer repos reference this branch (`@rory-ga-t1c-composer-cache`) in companion draft PRs.

### Linked PRs

- [Auth#22355](https://github.com/Expensify/Auth/pull/22355)
- [Web-Expensify#53848](https://github.com/Expensify/Web-Expensify/pull/53848)
- [Web-Secure#2981](https://github.com/Expensify/Web-Secure/pull/2981)
- [PHP-Libs#1331](https://github.com/Expensify/PHP-Libs/pull/1331)