### PR TITLE
Add TypeScript typechecking

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - "**/*.ts"
-      - "**/*.[mc]ts"
+      - "**/*.[tj]s"
+      - "**/*.?[tj]s"
       - "tsconfig.json"
       - "package.json"
       - "package-lock.json"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,39 @@
+name: Typecheck
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "**/*.ts"
+      - "**/*.[mc]ts"
+      - "tsconfig.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".nvmrc"
+      - ".github/workflows/typecheck.yml"
+
+jobs:
+  typecheck:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      # v6.1.0
+      - name: Setup Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Tell people how to run the failing check
+        if: failure()
+        run: echo "::error::The typecheck check failed! To run it locally, run \`npm ci && npm run typecheck\` from the GitHub-Actions repo root."

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
         "expensify-common": "2.0.189"
       },
       "devDependencies": {
+        "@types/node": "^25.9.4",
+        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
         "tsx": "^4.22.5"
       }
     },
@@ -454,6 +456,133 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/awesome-phonenumber": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/awesome-phonenumber/-/awesome-phonenumber-5.11.0.tgz",
@@ -802,6 +931,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.4",
-        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
+        "@typescript/native-preview": "7.0.0-dev.20260702.3",
         "tsx": "^4.22.5"
       }
     },
@@ -467,28 +467,31 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-j21laxUja23ex6qYGjwiSiQ6YpS/p5E7lCMDYKDBAdBv93Z1NzV96BZV3gdRwl+buH09EPuBAiqxKQqRO1grhw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsgo": "bin/tsgo.js"
+        "tsgo": "bin/tsgo"
+      },
+      "engines": {
+        "node": ">=16.20.0"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260702.3",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260702.3",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260702.3",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260702.3",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260702.3",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260702.3",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260702.3"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-sswJ7XRSH17/jDv6eqlRyNzjQev4w+TH+16RgeoZkKbQfZnVuLchF4ORCecEuia15X2yE8pbiQGY596LVbGKdA==",
       "cpu": [
         "arm64"
       ],
@@ -497,12 +500,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-j8ZYT/chWtx3QT1Bghp0/+2g6aKLaxRVpXEHt6Fjdj4OXQTpH4pljOE0+LeAqaET88PUo/XM9pi0TJ5TJwHLMg==",
       "cpu": [
         "x64"
       ],
@@ -511,12 +517,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-SM73Mp3oYUWkyHmym0MVfPnMeLGM6oo1vcPZTxVoL7BOKWkJKK+iM7D1tcqDSZNPwURSkWMxP17Dh+4JPqzikg==",
       "cpu": [
         "arm"
       ],
@@ -525,12 +534,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-FEBt9UER27yvn3o4quXZ9fQ/Hd39hxFPljJe8dxstCvyYLh0A9TwDuuwghWCisp5U9TDWWtl8m1GLjvqIKc6IA==",
       "cpu": [
         "arm64"
       ],
@@ -539,12 +551,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-CY/r7gHjDnf3xWptpQVRQnagMdUDbh+zL01SF+cTJsg1WVY3TtVNrCo48dwAnJL+U97qx1SKaGVsi/8cSPwrZA==",
       "cpu": [
         "x64"
       ],
@@ -553,12 +568,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-9U/ahdJAWZdYxPdNry3VAhB9avaQCiqsEk2PfheeKrKSKCtfs5FoPXy/QXAaIGIBK/Lw4a7OqyVyEbd0i77TkQ==",
       "cpu": [
         "arm64"
       ],
@@ -567,12 +585,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260421.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
-      "integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+      "version": "7.0.0-dev.20260702.3",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260702.3.tgz",
+      "integrity": "sha512-kPqfivHuzzEK2NFEl2QeCCiWJ4qkGMJYFX9TmJ4ylh784XICgQLX3PJe7OCqZcUicfeMIIDu6m3flcCi+4tW4Q==",
       "cpu": [
         "x64"
       ],
@@ -581,7 +602,10 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/awesome-phonenumber": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.4",
-    "@typescript/native-preview": "^7.0.0-dev.20260421.2",
+    "@typescript/native-preview": "7.0.0-dev.20260702.3",
     "tsx": "^4.22.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "verify-peer-review": "tsx scripts/verifyPeerReview.ts"
   },
   "dependencies": {
     "expensify-common": "2.0.189"
   },
   "devDependencies": {
+    "@types/node": "^25.9.4",
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2",
     "tsx": "^4.22.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "target": "ES2022",
+        "types": ["node"],
+        "strict": true,
+        "noEmit": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true
+    },
+    "include": ["scripts/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
### Details

Adds `tsgo`-based TypeScript typechecking (`tsconfig.json` + `typecheck` npm script + `.github/workflows/typecheck.yml`).

### Related Issues
https://github.com/Expensify/Expensify/issues/636197

### Manual Tests
1. Run `cd GitHub-Actions && nvm use && npm install`.
2. Run `npm run typecheck`.
3. Confirm it passes with no errors (verified locally).

### Linked PRs

N/A