### PR TITLE
Add tests for verifyPeerReview CLI skeleton

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - "**/*.[tj]s"
-      - "**/*.?[tj]s"
-      - "tsconfig.json"
-      - "package.json"
-      - "package-lock.json"
-      - ".nvmrc"
-      - ".github/workflows/test.yml"
+      - '**/*.[tj]s'
+      - '**/*.?[tj]s'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.nvmrc'
+      - '.github/workflows/test.yml'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "**/*.[tj]s"
+      - "**/*.?[tj]s"
+      - "tsconfig.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".nvmrc"
+      - ".github/workflows/test.yml"
+
+jobs:
+  test:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      # v6.1.0
+      - name: Setup Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Tell people how to run the failing check
+        if: failure()
+        run: echo "::error::The test check failed! To run it locally, run \`npm ci && npm test\` from the GitHub-Actions repo root."

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "verify-peer-review": "tsx scripts/verifyPeerReview.ts"
+    "verify-peer-review": "tsx scripts/verifyPeerReview.ts",
+    "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "expensify-common": "2.0.189"

--- a/tests/verifyPeerReviewCli.test.ts
+++ b/tests/verifyPeerReviewCli.test.ts
@@ -1,41 +1,33 @@
-import assert from "node:assert/strict";
-import { afterEach, beforeEach, describe, it } from "node:test";
-import VerifyPeerReview from "../scripts/verifyPeerReview";
+import assert from 'node:assert/strict';
+import {afterEach, beforeEach, describe, it} from 'node:test';
+
+import VerifyPeerReview from '../scripts/verifyPeerReview';
 
 const ORIGINAL_ARGV = process.argv;
 
-describe("main CLI parsing", () => {
-  let originalExit: typeof process.exit;
+describe('main CLI parsing', () => {
+    let originalExit: typeof process.exit;
 
-  beforeEach(() => {
-    process.argv = ["tsx", "scripts/verifyPeerReview.ts"];
-    originalExit = process.exit.bind(process);
-    process.exit = (code?: string | number | null) => {
-      throw new Error(`exit ${code ?? 0}`);
-    };
-  });
+    beforeEach(() => {
+        process.argv = ['tsx', 'scripts/verifyPeerReview.ts'];
+        originalExit = process.exit.bind(process);
+        process.exit = (code?: string | number | null) => {
+            throw new Error(`exit ${code ?? 0}`);
+        };
+    });
 
-  afterEach(() => {
-    process.argv = ORIGINAL_ARGV;
-    process.exit = originalExit;
-  });
+    afterEach(() => {
+        process.argv = ORIGINAL_ARGV;
+        process.exit = originalExit;
+    });
 
-  it("parses required pull request CLI arguments", async () => {
-    process.argv.push(
-      "--owner",
-      "Expensify",
-      "--repo",
-      "Auth",
-      "--pull-request-number",
-      "21136",
-      "--base-ref",
-      "main",
-    );
+    it('parses required pull request CLI arguments', async () => {
+        process.argv.push('--owner', 'Expensify', '--repo', 'Auth', '--pull-request-number', '21136', '--base-ref', 'main');
 
-    await assert.doesNotReject(() => VerifyPeerReview.main());
-  });
+        await assert.doesNotReject(() => VerifyPeerReview.main());
+    });
 
-  it("fails when required arguments are missing", async () => {
-    await assert.rejects(() => VerifyPeerReview.main(), /exit 1/);
-  });
+    it('fails when required arguments are missing', async () => {
+        await assert.rejects(() => VerifyPeerReview.main(), /exit 1/);
+    });
 });

--- a/tests/verifyPeerReviewCli.test.ts
+++ b/tests/verifyPeerReviewCli.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import VerifyPeerReview from "../scripts/verifyPeerReview";
+
+const ORIGINAL_ARGV = process.argv;
+
+describe("main CLI parsing", () => {
+  let originalExit: typeof process.exit;
+
+  beforeEach(() => {
+    process.argv = ["tsx", "scripts/verifyPeerReview.ts"];
+    originalExit = process.exit.bind(process);
+    process.exit = (code?: string | number | null) => {
+      throw new Error(`exit ${code ?? 0}`);
+    };
+  });
+
+  afterEach(() => {
+    process.argv = ORIGINAL_ARGV;
+    process.exit = originalExit;
+  });
+
+  it("parses required pull request CLI arguments", async () => {
+    process.argv.push(
+      "--owner",
+      "Expensify",
+      "--repo",
+      "Auth",
+      "--pull-request-number",
+      "21136",
+      "--base-ref",
+      "main",
+    );
+
+    await assert.doesNotReject(() => VerifyPeerReview.main());
+  });
+
+  it("fails when required arguments are missing", async () => {
+    await assert.rejects(() => VerifyPeerReview.main(), /exit 1/);
+  });
+});


### PR DESCRIPTION
### Details

Adds a test file for `scripts/verifyPeerReview.ts`'s CLI argument parsing:

- `tests/verifyPeerReviewCli.test.ts` — exercises CLI argument parsing (owner/repo/pull-request-number/base-ref, via `expensify-common/CLI`) against `scripts/verifyPeerReview.ts`. The script currently only parses and logs its CLI arguments (it doesn't call the GitHub API yet), so the test only covers argument parsing.
- `.github/workflows/test.yml` — CI workflow that runs `npm test` on relevant file changes.
- A `test` npm script (`tsx --test tests/*.test.ts`), using Node's built-in `node:test` runner. No new dependencies were needed since `tsx` was already a devDependency.

Verified the CLI's missing-required-argument behavior directly against `node_modules/expensify-common/dist/CLI.js`: when a required named arg is missing, the constructor throws `Error("Missing required named argument --<name>")`, which is caught internally and results in a synchronous `process.exit(1)` call. Since the test mocks `process.exit` to throw, and `main()` constructs the `CLI` synchronously (not awaited), this manifests as `main()`'s returned promise rejecting with `exit 1` — matching the assertion in the test.

### Related Issues

https://github.com/Expensify/Expensify/issues/636197

### Manual Tests

Ran `npm test` locally — both test cases pass (parses required CLI args successfully; fails when required args are missing).

### Linked PRs

N/A

Made with [Cursor](https://cursor.com)
