### PR TITLE
Add Oxfmt code formatting

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -62,7 +62,7 @@ jobs:
 
           # Find all files changes with package*.json
           FILES=$(git status --porcelain -- package*.json | awk '{ print $2 }')
-  
+
           for file in $FILES; do
             message="Update $file version to $version"
             sha=$(git rev-parse "main:$file")
@@ -76,18 +76,18 @@ jobs:
               --field sha="$sha" \
               --jq '.commit.sha')
           done
-          
+
           # Set up git user info so we can push a tag
           # os-botify[bot] GitHub App ID can be found here: https://api.github.com/users/os-botify[bot]
           git config --global user.name "os-botify[bot]"
           git config --global user.email "140437396+os-botify[bot]@users.noreply.github.com"
-          
+
           # Fetch the commit that was made via the API
           git fetch origin main
 
           # Tag new_commit_sha with our new version
           git tag -a "$version" "$new_commit_sha" -m "$version"
-          
+
           # Push the new tag
           git push origin tag "$version"
         env:

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -1,0 +1,40 @@
+name: Oxfmt
+
+on:
+  workflow_call:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "**.[tj]s"
+      - ".oxfmtrc.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".nvmrc"
+      - ".github/workflows/oxfmt.yml"
+
+jobs:
+  oxfmt:
+    if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        # 4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup Node
+        # v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Check formatting with Oxfmt
+        run: npx oxfmt --check .
+
+      - name: Tell people how to run the failing check
+        if: failure()
+        run: echo "::error::The Oxfmt check failed! Run \`npm run fmt\` from the GitHub-Actions repo root and commit the changes."

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -5,12 +5,14 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - "**.[tj]s"
-      - ".oxfmtrc.json"
-      - "package.json"
-      - "package-lock.json"
-      - ".nvmrc"
-      - ".github/workflows/oxfmt.yml"
+      - '**.[tj]s'
+      - '**.yml'
+      - '**.yaml'
+      - '.oxfmtrc.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.nvmrc'
+      - '.github/workflows/oxfmt.yml'
 
 jobs:
   oxfmt:

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -5,15 +5,15 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - "**/*.[tj]s"
-      - "**/*.?[tj]s"
-      - "**.yml"
-      - "**.yaml"
-      - ".oxfmtrc.json"
-      - "package.json"
-      - "package-lock.json"
-      - ".nvmrc"
-      - ".github/workflows/oxfmt.yml"
+      - '**/*.[tj]s'
+      - '**/*.?[tj]s'
+      - '**.yml'
+      - '**.yaml'
+      - '.oxfmtrc.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.nvmrc'
+      - '.github/workflows/oxfmt.yml'
 
 jobs:
   oxfmt:

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -5,14 +5,15 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '**.[tj]s'
-      - '**.yml'
-      - '**.yaml'
-      - '.oxfmtrc.json'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.nvmrc'
-      - '.github/workflows/oxfmt.yml'
+      - "**/*.[tj]s"
+      - "**/*.?[tj]s"
+      - "**.yml"
+      - "**.yaml"
+      - ".oxfmtrc.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".nvmrc"
+      - ".github/workflows/oxfmt.yml"
 
 jobs:
   oxfmt:

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # 4.2.2
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup Node
         # v6.4.0

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,14 @@
+{
+    "tabWidth": 4,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "bracketSpacing": false,
+    "arrowParens": "always",
+    "printWidth": 190,
+    "singleAttributePerLine": true,
+    "sortPackageJson": false,
+    "sortImports": {
+        "ignoreCase": true
+    },
+    "ignorePatterns": ["package.json", "package-lock.json", "*.yml", "*.yaml", "*.md", "*.markdown", "dist/**"]
+}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,5 +10,13 @@
     "sortImports": {
         "ignoreCase": true
     },
-    "ignorePatterns": ["package.json", "package-lock.json", "*.yml", "*.yaml", "*.md", "*.markdown", "dist/**"]
+    "ignorePatterns": ["package.json", "package-lock.json", "*.md", "*.markdown", "dist/**"],
+    "overrides": [
+        {
+            "files": ["*.yml", "*.yaml"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "expensify-common": "2.0.189"
       },
       "devDependencies": {
+        "oxfmt": "^0.57.0",
         "tsx": "^4.22.5"
       }
     },
@@ -454,6 +455,353 @@
         "node": ">=18"
       }
     },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.57.0.tgz",
+      "integrity": "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.57.0.tgz",
+      "integrity": "sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.57.0.tgz",
+      "integrity": "sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.57.0.tgz",
+      "integrity": "sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.57.0.tgz",
+      "integrity": "sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.57.0.tgz",
+      "integrity": "sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.57.0.tgz",
+      "integrity": "sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.57.0.tgz",
+      "integrity": "sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.57.0.tgz",
+      "integrity": "sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.57.0.tgz",
+      "integrity": "sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.57.0.tgz",
+      "integrity": "sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.57.0.tgz",
+      "integrity": "sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.57.0.tgz",
+      "integrity": "sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.57.0.tgz",
+      "integrity": "sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.57.0.tgz",
+      "integrity": "sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.57.0.tgz",
+      "integrity": "sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.57.0.tgz",
+      "integrity": "sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.57.0.tgz",
+      "integrity": "sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.57.0.tgz",
+      "integrity": "sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/awesome-phonenumber": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/awesome-phonenumber/-/awesome-phonenumber-5.11.0.tgz",
@@ -661,6 +1009,58 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oxfmt": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.57.0.tgz",
+      "integrity": "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.57.0",
+        "@oxfmt/binding-android-arm64": "0.57.0",
+        "@oxfmt/binding-darwin-arm64": "0.57.0",
+        "@oxfmt/binding-darwin-x64": "0.57.0",
+        "@oxfmt/binding-freebsd-x64": "0.57.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.57.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.57.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.57.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.57.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-x64-musl": "0.57.0",
+        "@oxfmt/binding-openharmony-arm64": "0.57.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.57.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.57.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.57.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -757,6 +1157,16 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
     },
     "node_modules/tsx": {
       "version": "4.22.5",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "fmt": "oxfmt --write .",
     "verify-peer-review": "tsx scripts/verifyPeerReview.ts"
   },
   "dependencies": {
     "expensify-common": "2.0.189"
   },
   "devDependencies": {
+    "oxfmt": "^0.57.0",
     "tsx": "^4.22.5"
   }
 }

--- a/scripts/verifyPeerReview.ts
+++ b/scripts/verifyPeerReview.ts
@@ -1,50 +1,48 @@
 #!/usr/bin/env -S node --import tsx
 
-import CLI from "expensify-common/CLI";
+import CLI from 'expensify-common/CLI';
 
 async function main(): Promise<void> {
-  /* eslint-disable @typescript-eslint/naming-convention -- CLI uses kebab-case argument names */
-  const cli = new CLI({
-    namedArgs: {
-      owner: {
-        description: "Repository owner organization or user login",
-      },
-      repo: {
-        description: "Repository name",
-      },
-      "pull-request-number": {
-        description: "Pull request number",
-        parse: (value: string) => {
-          const number = Number(value);
-          if (!Number.isInteger(number) || number <= 0) {
-            throw new Error("Must be a positive integer");
-          }
-          return number;
+    /* eslint-disable @typescript-eslint/naming-convention -- CLI uses kebab-case argument names */
+    const cli = new CLI({
+        namedArgs: {
+            owner: {
+                description: 'Repository owner organization or user login',
+            },
+            repo: {
+                description: 'Repository name',
+            },
+            'pull-request-number': {
+                description: 'Pull request number',
+                parse: (value: string) => {
+                    const number = Number(value);
+                    if (!Number.isInteger(number) || number <= 0) {
+                        throw new Error('Must be a positive integer');
+                    }
+                    return number;
+                },
+            },
+            'base-ref': {
+                description: 'Target branch ref for the pull request',
+            },
         },
-      },
-      "base-ref": {
-        description: "Target branch ref for the pull request",
-      },
-    },
-  });
-  /* eslint-enable @typescript-eslint/naming-convention */
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
 
-  const owner = cli.namedArgs.owner;
-  const repo = cli.namedArgs.repo;
-  const pullRequestNumber = cli.namedArgs["pull-request-number"];
-  const baseRef = cli.namedArgs["base-ref"];
+    const owner = cli.namedArgs.owner;
+    const repo = cli.namedArgs.repo;
+    const pullRequestNumber = cli.namedArgs['pull-request-number'];
+    const baseRef = cli.namedArgs['base-ref'];
 
-  // TODO: replace this no-op with the real independent-peer-review check.
-  console.log(
-    `Verify peer review skeleton invoked for ${owner}/${repo}#${pullRequestNumber} (base: ${baseRef}). Always passes for now.`,
-  );
+    // TODO: replace this no-op with the real independent-peer-review check.
+    console.log(`Verify peer review skeleton invoked for ${owner}/${repo}#${pullRequestNumber} (base: ${baseRef}). Always passes for now.`);
 }
 
-export default { main };
+export default {main};
 
 if (import.meta.main) {
-  main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  });
+    main().catch((error: unknown) => {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+    });
 }

--- a/setup-certificate-1p/action.yml
+++ b/setup-certificate-1p/action.yml
@@ -8,7 +8,7 @@ inputs:
   SHOULD_LOAD_SSL_CERTIFICATES:
     description: Whether the action needs to set up SSL certificates
     required: false
-    default: "true"
+    default: 'true'
 
 runs:
   using: composite
@@ -26,4 +26,3 @@ runs:
       shell: bash
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
-

--- a/setup-composer-cache/action.yml
+++ b/setup-composer-cache/action.yml
@@ -5,15 +5,15 @@ inputs:
   working_directory:
     description: Directory containing composer.json and composer.lock
     required: false
-    default: "."
+    default: '.'
   dev:
     description: Install dev packages when run_install is true
     required: false
-    default: "false"
+    default: 'false'
   run_install:
     description: Run composer install after restoring caches
     required: false
-    default: "false"
+    default: 'false'
 
 runs:
   using: composite


### PR DESCRIPTION
### Details

Adds Oxfmt code formatting to the repo:

- `.oxfmtrc.json` — `tabWidth: 4`, `singleQuote: true`, `trailingComma: "all"`, `bracketSpacing: false`, `arrowParens: "always"`, `printWidth: 190`, `singleAttributePerLine: true`, matching Expensify's established JS/TS formatting conventions. `sortImports` uses Oxfmt's basic case-insensitive sorting with no custom groups, since this repo has no path aliases.
- `.github/workflows/oxfmt.yml` — CI check using `oxfmt --check .` (Oxfmt has a native check-only mode), matching this repo's existing workflow conventions (`blacksmith-2vcpu-ubuntu-2404`, pinned action SHAs, path-filtered `pull_request` trigger).
- A `fmt` npm script (`oxfmt --write .`) and the `oxfmt` devDependency.
- Reformatted `scripts/verifyPeerReview.ts` with `npm run fmt` (4-space indent, single quotes, no bracket spacing) so the repo stays consistently formatted going forward.

This repo uses Oxfmt (a native Rust formatter) rather than Prettier, consistent with [what we now use in App](https://expensify.slack.com/archives/C01GTK53T8Q/p1783051659644459?thread_ts=1782931409.372049&cid=C01GTK53T8Q), used here as a reference for config conventions).

### Related Issues

https://github.com/Expensify/Expensify/issues/636197

### Manual Tests

Ran `npm run fmt` locally — it formats `scripts/verifyPeerReview.ts` as expected, and `npx oxfmt --check .` passes cleanly afterward. Verified the reformatted script still runs correctly.

### Linked PRs

N/A