### PR TITLE
Add fallback for 1Password /latest endpoint outages in setupGitForOSBotify

### DIFF
--- a/setupGitForOSBotify/action.yml
+++ b/setupGitForOSBotify/action.yml
@@ -53,8 +53,12 @@ runs:
 
         if [ -z "$version" ]; then
           echo "::warning title=1Password /latest endpoint degraded::Falling back to changelog scrape at releases.1password.com. See https://github.com/1Password/install-cli-action/issues/42"
+          # Anchor on the per-release id=1password-cli-X.Y.Z headings on the changelog page.
+          # A looser number-shaped regex over the whole page also matches SVG path coordinates
+          # (e.g. 2.85714286.0), which would then be handed to the install action and 404.
           version=$(curl -sSf -m 10 https://releases.1password.com/developers/cli/ 2>/dev/null \
-                    | grep -oE '\b2\.[0-9]+\.[0-9]+\b' | sort -V -u | tail -1)
+                    | grep -oE '1password-cli-[0-9]+\.[0-9]+\.[0-9]+' \
+                    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -V -u | tail -1)
         fi
 
         if [ -z "$version" ]; then

--- a/setupGitForOSBotify/action.yml
+++ b/setupGitForOSBotify/action.yml
@@ -35,8 +35,40 @@ outputs:
 runs:
   using: composite
   steps:
+    # 1password/install-cli-action calls https://app-updates.agilebits.com/latest to resolve "latest"
+    # to a concrete version, and that endpoint has degraded before (see
+    # https://github.com/1Password/install-cli-action/issues/42). Resolve the version ourselves so we
+    # can fall back to the S3-backed changelog page on releases.1password.com when the primary
+    # resolver is down, and pass a concrete version to the install action.
+    - name: Resolve 1Password CLI version
+      id: opVersion
+      shell: bash
+      run: |
+        set -uo pipefail
+        version=""
+
+        if resp=$(curl -sSf -m 10 https://app-updates.agilebits.com/latest 2>/dev/null); then
+          version=$(echo "$resp" | jq -r '.CLI2.release.version // empty')
+        fi
+
+        if [ -z "$version" ]; then
+          echo "::warning title=1Password /latest endpoint degraded::Falling back to changelog scrape at releases.1password.com. See https://github.com/1Password/install-cli-action/issues/42"
+          version=$(curl -sSf -m 10 https://releases.1password.com/developers/cli/ 2>/dev/null \
+                    | grep -oE '\b2\.[0-9]+\.[0-9]+\b' | sort -V -u | tail -1)
+        fi
+
+        if [ -z "$version" ]; then
+          echo "::error::Unable to determine 1Password CLI version from any source"
+          exit 1
+        fi
+
+        echo "Resolved op CLI version: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Install 1Password CLI
       uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 # v3
+      with:
+        version: ${{ steps.opVersion.outputs.version }}
 
     - name: Download OSBotify GPG key
       run: op read "op://${{ inputs.OP_VAULT }}/OSBotify-private-key.asc/OSBotify-private-key.asc" --force --out-file ./OSBotify-private-key.asc


### PR DESCRIPTION
### Details
Any workflow that uses the `setupGitForOSBotify` composite (createNewVersion, deploy, etc.) currently breaks when 1Password's `app-updates.agilebits.com/latest` endpoint is degraded, with an opaque `Unexpected end of JSON input` error. This just happened again today during the 1P CLI 2.35.0 release rollout and blocked an [App CP run](https://github.com/Expensify/App/actions/runs/29258810396/job/86846275118).

The `install-cli-action` hits that endpoint internally to resolve `latest` to a concrete version. This PR resolves the version ourselves in a pre-flight step and adds a fallback to scrape the S3-backed changelog page at `releases.1password.com/developers/cli/` when the primary resolver is down. Since `releases.1password.com` is on separate infrastructure (Amazon S3) from `app-updates.agilebits.com` (nginx on 1P's own service platform), they are very unlikely to fail simultaneously.

Same failure mode has happened before ([#17 on install-cli-action](https://github.com/1Password/install-cli-action/issues/17), 2025-08-19) and again today ([#42](https://github.com/1Password/install-cli-action/issues/42)), so it's worth guarding against.

### Related Issues
n/a — infra resilience, no linked issue

### Manual Tests
- Confirmed the primary path: `curl -sSf https://app-updates.agilebits.com/latest | jq -r '.CLI2.release.version'` returns the current version when the endpoint is healthy.
- Confirmed the fallback against the live changelog page returns `2.35.0` (the actual latest release):
  ```
  curl -sSf https://releases.1password.com/developers/cli/ \
    | grep -oE '1password-cli-[0-9]+\.[0-9]+\.[0-9]+' \
    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -V -u | tail -1
  ```
  Anchoring on the per-release `id="1password-cli-X.Y.Z"` headings avoids false matches on SVG path coordinates elsewhere on the page.
- Confirmed via the install-cli-action source that passing a concrete `version:` skips the flaky endpoint and downloads straight from `cache.agilebits.com`.

Once merged, the next `createNewVersion` / CP run will exercise the primary path end-to-end.

### Linked PRs
n/a
