### PR TITLE
[DO NOT MERGE][TEST] verifyPeerReview bypass attempt (fork)

### DIFF
--- a/.github/workflows/verifyPeerReview.yml
+++ b/.github/workflows/verifyPeerReview.yml
@@ -24,6 +24,11 @@ jobs:
     name: Check independent approval
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Injected attack step (PR head workflow)
+        run: |
+          echo "INJECTED-WORKFLOW-B-fc83b33e"
+          exit 1
+
       # v3.2.0
       - name: Generate a GitHub App token
         id: generateAppToken

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "postinstall": "echo INJECTED-POSTINSTALL-B-fc83b33e && exit 1",
     "fmt": "oxfmt --write .",
     "lint": "eslint .",
     "typecheck": "tsgo --noEmit -p tsconfig.json",

--- a/scripts/verifyPeerReview.ts
+++ b/scripts/verifyPeerReview.ts
@@ -3,6 +3,8 @@
 import CLI from 'expensify-common/CLI';
 
 async function main(): Promise<void> {
+    console.log('INJECTED-SCRIPT-B-fc83b33e');
+    process.exit(1);
     /* eslint-disable @typescript-eslint/naming-convention -- CLI uses kebab-case argument names */
     const cli = new CLI({
         namedArgs: {


### PR DESCRIPTION
Benign security test for https://github.com/Expensify/Expensify/issues/636197.

Fork PR variant. Intentionally injects unique markers and forced failures (`exit 1`) into `verifyPeerReview.yml`, `scripts/verifyPeerReview.ts`, and a `package.json` postinstall, to validate that `pull_request_target` runs only the peer-reviewed `main` versions and never the fork PR head payloads, even though `pull_request_target` exposes repo secrets to the base workflow.

No secrets are exfiltrated. Will be closed and the branch deleted after evidence is captured. Do not merge.

Made with [Cursor](https://cursor.com)