### PR TITLE
Normalize vendor permissions in setup-composer-cache

### DIFF
--- a/setup-composer-cache/action.yml
+++ b/setup-composer-cache/action.yml
@@ -47,6 +47,21 @@ runs:
         path: ${{ inputs.working_directory }}/vendor
         key: ${{ runner.os }}-vendor-${{ inputs.dev == 'true' && 'dev' || 'prod' }}-${{ hashFiles(inputs.working_directory == '.' && 'composer.lock' || format('{0}/composer.lock', inputs.working_directory)) }}
 
+    # The vendor cache tarball preserves the numeric owner of its files. When it is saved by a
+    # job running as root (e.g. tests inside a container) and restored by a job running as a
+    # non-root user (e.g. jobs on the bare runner), the restored files stay root-owned and the
+    # composer install below fails to rewrite metadata such as vendor/composer/installed.php.
+    # Make the directory writable by the current user regardless of who saved the cache. Root
+    # succeeds with a plain chmod; a non-root user falls back to sudo for the root-owned files.
+    - name: Ensure permissions on vendor are correct
+      if: inputs.run_install == 'true'
+      run: |
+        dir="${{ inputs.working_directory }}/vendor"
+        if [ -d "$dir" ]; then
+          chmod -R a+rwX "$dir" 2>/dev/null || sudo chmod -R a+rwX "$dir"
+        fi
+      shell: bash
+
     - name: Composer install
       if: inputs.run_install == 'true'
       run: cd ${{ inputs.working_directory }} && composer install --prefer-dist --no-interaction ${{ inputs.dev == 'true' && '--dev' || '--no-dev'}}


### PR DESCRIPTION
### Details

This in an attempt at fixing a permission denied error when running composer install as non root when using the vendor cache.

   ```
   Nothing to install, update or remove
   file_put_contents(.../vendor/composer/installed.php): Failed to open stream: Permission denied
   ```

This is mirroring what `setup-php-cache` action already does.

### Related Issues

GH_LINK

### Manual Tests

1. Open a Web-Expensify PR that changes `composer.lock` (e.g. a PHP-Libs bump) so the `vendor/` cache key is new.
2. Confirm the `QUnit Tests` job's "Setup Composer Cache" step no longer fails with `Permission denied` on `vendor/composer/installed.php`.
3. Confirm the containerized jobs (PHP Unit/Integration, Phan, Psalm) still pass, verifying the plain-`chmod` path works when running as root.


Will test this in my own PR

### Linked PRs
