### PR TITLE
Update useblacksmith/checkout to 1c9394c (# v1)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # 6.0.3
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
 
       # v6.1.0
       - name: Setup Node

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -21,8 +21,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v7
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
 
       - name: Setup Node
         # v6.4.0

--- a/.github/workflows/shellCheck.yml
+++ b/.github/workflows/shellCheck.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # 4.2.2
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
 
       - name: Lint shell scripts with ShellCheck
         run: ./scripts/shellCheck.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # 6.0.3
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
 
       # v6.1.0
       - name: Setup Node

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # 6.0.3
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
 
       # v6.1.0
       - name: Setup Node

--- a/.github/workflows/verifyPeerReview.yml
+++ b/.github/workflows/verifyPeerReview.yml
@@ -43,7 +43,7 @@ jobs:
 
       # v7.0.0
       - name: Checkout GitHub-Actions
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
         with:
           repository: Expensify/GitHub-Actions
           path: GitHub-Actions

--- a/checkoutRepoAndGitHubActions/action.yml
+++ b/checkoutRepoAndGitHubActions/action.yml
@@ -14,14 +14,13 @@ runs:
       run: echo "NAME=$(basename ${{ github.repository }})" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    # v4.2.2
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
       with:
         path: ${{ steps.repo.outputs.NAME }}
 
     - name: Checkout Expensify/GitHub-Actions
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
       with:
         repository: Expensify/GitHub-Actions
         path: GitHub-Actions


### PR DESCRIPTION
### Details

Pin `useblacksmith/checkout` to `1c9394c220d293645707b625ba9d79685f093a8f` (# v1) in Blacksmith-hosted workflows and `checkoutRepoAndGitHubActions`. `npmPublish` stays on `actions/checkout` (ubuntu-latest).

### Related Issues

N/A

### Manual Tests

N/A — CI only.

### Linked PRs

N/A
