### PR TITLE
Add canonical shared-rules mechanism to claude-review-toolkit

### DIFF
--- a/.github/actions/claude-review-toolkit/README.md
+++ b/.github/actions/claude-review-toolkit/README.md
@@ -25,6 +25,14 @@ It places a set of helper scripts on `GITHUB_PATH`, exposes the canonical violat
 
 Caller repos must ship a `.claude/skills/coding-standards/rules/` directory with at least one `.md` rule file whose YAML frontmatter declares a `ruleId:` tag matching `[A-Z]+(-[A-Z]+)*-[0-9]+` (e.g. `PERF-1`, `GEN-01`, `CLEAN-REACT-PATTERNS-0`). The action's extract step builds an allowlist from those tags and fails the workflow if the directory is missing or yields no tags.
 
+## Shared rules
+
+`shared-rules/` holds rule files that are genuinely repo-agnostic and apply to every caller (currently just `GEN-04`, the comment-why rule). The action copies each of these into the caller's `.claude/skills/coding-standards/rules/` directory as `AutoLoadShared-<file>.md` before extracting the allowlist, so a caller repo's `code-inline-reviewer` picks it up the same way it picks up its own local rule files, with no per-repo copy to keep in sync. The copy is created fresh in the ephemeral workflow checkout on every run and is never committed to the caller repo.
+
+A caller's `code-inline-reviewer.md` agent definition should treat a rule file whose name starts with `AutoLoadShared-` as documented here rather than in the caller's own repo, and build its `(docs)` comment link accordingly (strip the prefix and link to `shared-rules/<file>.md` in this repo). `ruleId` still comes from the file's YAML frontmatter, so the prefix has no effect on rule identity or the allowlist.
+
+Adding a new shared rule: drop the `.md` file into `shared-rules/`, then in each caller repo delete any local copy that duplicates it (to avoid the reviewer loading the same `ruleId` twice) and verify the local rule content was actually identical across repos before deleting; a rule that has already drifted into repo-specific examples should stay local instead.
+
 ## Outputs
 
 | Name | Description |

--- a/.github/actions/claude-review-toolkit/README.md
+++ b/.github/actions/claude-review-toolkit/README.md
@@ -27,11 +27,11 @@ Caller repos must ship a `.claude/skills/coding-standards/rules/` directory with
 
 ## Shared rules
 
-`shared-rules/` holds rule files that are genuinely repo-agnostic and apply to every caller (currently just `GEN-04`, the comment-why rule). The action copies each of these into the caller's `.claude/skills/coding-standards/rules/` directory as `AutoLoadShared-<file>.md` before extracting the allowlist, so a caller repo's `code-inline-reviewer` picks it up the same way it picks up its own local rule files, with no per-repo copy to keep in sync. The copy is created fresh in the ephemeral workflow checkout on every run and is never committed to the caller repo.
+`shared-rules/` holds rule files that are genuinely repo-agnostic and apply to every caller. The GH action copies each of these into the caller's `.claude/skills/coding-standards/rules/` directory before extracting the allowlist. Each copy is named `AutoLoadShared-<file>.md`, so a caller repo's `code-inline-reviewer` picks it up the same way it picks up its own local rule files. There is no per-repo copy to keep in sync. The copy is created fresh in the ephemeral workflow checkout on every run and is never committed to the caller repo.
 
-A caller's `code-inline-reviewer.md` agent definition should treat a rule file whose name starts with `AutoLoadShared-` as documented here rather than in the caller's own repo, and build its `(docs)` comment link accordingly (strip the prefix and link to `shared-rules/<file>.md` in this repo). `ruleId` still comes from the file's YAML frontmatter, so the prefix has no effect on rule identity or the allowlist.
+A caller's `code-inline-reviewer.md` agent definition should treat a rule file whose name starts with `AutoLoadShared-` as documented here rather than in the caller's own repo. It should also build its `(docs)` comment link accordingly. To do that, strip the prefix and link to `shared-rules/<file>.md` in this repo. `ruleId` still comes from the file's YAML frontmatter, so the prefix has no effect on rule identity or the allowlist.
 
-Adding a new shared rule: drop the `.md` file into `shared-rules/`, then in each caller repo delete any local copy that duplicates it (to avoid the reviewer loading the same `ruleId` twice) and verify the local rule content was actually identical across repos before deleting; a rule that has already drifted into repo-specific examples should stay local instead.
+To add a new shared rule, drop the `.md` file into `shared-rules/`. Then, in each caller repo, delete any local copy that duplicates it, so the reviewer doesn't load the same `ruleId` twice. Verify the local rule content was actually identical across repos before deleting it. A rule that has already drifted into repo-specific examples should stay local instead.
 
 ## Outputs
 

--- a/.github/actions/claude-review-toolkit/action.yml
+++ b/.github/actions/claude-review-toolkit/action.yml
@@ -19,6 +19,15 @@ runs:
       run: |
         echo "schema_path=$GITHUB_ACTION_PATH/schemas/code-review-output.json" >> "$GITHUB_OUTPUT"
         echo "schema_json=$(jq -c . "$GITHUB_ACTION_PATH/schemas/code-review-output.json")" >> "$GITHUB_OUTPUT"
+    - name: Copy shared coding-standards rules
+      shell: bash
+      run: |
+        RULES_DIR="$GITHUB_WORKSPACE/.claude/skills/coding-standards/rules"
+        mkdir -p "$RULES_DIR"
+        for rule_path in "$GITHUB_ACTION_PATH"/shared-rules/*.md; do
+          [[ -f "$rule_path" ]] || continue
+          cp "$rule_path" "$RULES_DIR/AutoLoadShared-$(basename "$rule_path")"
+        done
     - name: Extract allowed rules
       shell: bash
       run: |

--- a/.github/actions/claude-review-toolkit/action.yml
+++ b/.github/actions/claude-review-toolkit/action.yml
@@ -23,11 +23,16 @@ runs:
       shell: bash
       run: |
         RULES_DIR="$GITHUB_WORKSPACE/.claude/skills/coding-standards/rules"
-        mkdir -p "$RULES_DIR"
-        for rule_path in "$GITHUB_ACTION_PATH"/shared-rules/*.md; do
-          [[ -f "$rule_path" ]] || continue
-          cp "$rule_path" "$RULES_DIR/AutoLoadShared-$(basename "$rule_path")"
-        done
+        # Only copy into a rules directory the caller already ships. Creating
+        # it here would let extractAllowedRules.sh's missing-directory check
+        # silently pass with just the shared rules, hiding a caller repo that
+        # never set up code-inline-reviewer at all.
+        if [[ -d "$RULES_DIR" ]]; then
+          for rule_path in "$GITHUB_ACTION_PATH"/shared-rules/*.md; do
+            [[ -f "$rule_path" ]] || continue
+            cp "$rule_path" "$RULES_DIR/AutoLoadShared-$(basename "$rule_path")"
+          done
+        fi
     - name: Extract allowed rules
       shell: bash
       run: |

--- a/.github/actions/claude-review-toolkit/action.yml
+++ b/.github/actions/claude-review-toolkit/action.yml
@@ -23,11 +23,23 @@ runs:
       shell: bash
       run: |
         RULES_DIR="$GITHUB_WORKSPACE/.claude/skills/coding-standards/rules"
-        # Only copy into a rules directory the caller already ships. Creating
-        # it here would let extractAllowedRules.sh's missing-directory check
-        # silently pass with just the shared rules, hiding a caller repo that
-        # never set up code-inline-reviewer at all.
+        # Only copy in when the caller already has at least one valid local
+        # rule (a ruleId: tag matching extractAllowedRules.sh's own format).
+        # Copying into a missing, empty, or malformed caller directory would
+        # let a shared rule alone satisfy extractAllowedRules.sh's check, so
+        # a caller that never set up code-inline-reviewer at all would pass
+        # instead of failing.
+        has_valid_local_rule=false
         if [[ -d "$RULES_DIR" ]]; then
+          for rule_path in "$RULES_DIR"/[!_]*.md; do
+            [[ -f "$rule_path" ]] || continue
+            if grep -m1 '^ruleId:' "$rule_path" | grep -qE '[A-Z]+(-[A-Z]+)*-[0-9]+'; then
+              has_valid_local_rule=true
+              break
+            fi
+          done
+        fi
+        if [[ "$has_valid_local_rule" == true ]]; then
           for rule_path in "$GITHUB_ACTION_PATH"/shared-rules/*.md; do
             [[ -f "$rule_path" ]] || continue
             cp "$rule_path" "$RULES_DIR/AutoLoadShared-$(basename "$rule_path")"

--- a/.github/actions/claude-review-toolkit/shared-rules/gen-04-commenting-why.md
+++ b/.github/actions/claude-review-toolkit/shared-rules/gen-04-commenting-why.md
@@ -1,0 +1,9 @@
+---
+ruleId: GEN-04
+title: Commenting “Why”
+---
+
+#### [GEN-04] Commenting “Why”
+- **Condition**: Comments should explain *why* the code exists, not what it does.
+- ❌ `// loop through users`
+- ✅ `// we only include active users to avoid reprocessing deactivated ones`

--- a/.github/actions/claude-review-toolkit/shared-rules/gen-04-commenting-why.md
+++ b/.github/actions/claude-review-toolkit/shared-rules/gen-04-commenting-why.md
@@ -7,3 +7,22 @@ title: Commenting “Why”
 - **Condition**: Comments should explain *why* the code exists, not what it does.
 - ❌ `// loop through users`
 - ✅ `// we only include active users to avoid reprocessing deactivated ones`
+- **Condition**: Write comments in plain, simple language that reads well and sounds natural when read out loud. Avoid phrasing that reads as AI-generated noise.
+- **Condition**: Never use em dashes or en dashes in comments.
+- ❌ `// Set a specific domain AM — this exercises the domainAccountManagerID == accountID branch`
+- ✅ `// Set a specific domain AM to go through the domainAccountManagerID == accountID branch`
+- **Condition**: Avoid redundant parenthetical clarifications.
+- ❌ `// When the assigned guide (who is not a policy admin) comments, then it succeeds`
+- ✅ `// The assigned guide isn't a policy admin, but the comment still succeeds`
+- **Condition**: Avoid clunky hyphenated compound modifiers.
+- ❌ `// the not-yet-validated user-supplied bank-account number`
+- ✅ `// the bank account number the user supplied, before validation`
+- **Condition**: Never use "->" in comments. Write out the relationship in words.
+- ❌ `// peek -> process transition`
+- ✅ `// the transition from peek to process`
+- **Condition**: Avoid semicolons. Use separate sentences instead.
+- ❌ `// retry once; the endpoint is flaky`
+- ✅ `// retry once because the endpoint is flaky`
+- **Condition**: Put comments on their own line above the code they describe, never trailing at the end of a line.
+- ❌ `doThing(); // cache the result`
+- ✅ `// cache the result` on its own line, directly above `doThing();`


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
`code-inline-reviewer` loads its coding-standards rules from each repo's own committed `.claude/skills/coding-standards/rules/` directory, so GEN-04 (commenting why) has already drifted into three versions. Auth's copy uses curly quotes, Web-Expensify's copy uses straight quotes under a different filename, and App has no GEN-04 at all.

This adds `shared-rules/` to `claude-review-toolkit`, holding rules that are genuinely identical across repos. A new step in `action.yml` copies each shared rule into the caller's rules directory as `AutoLoadShared-<file>.md`, before the existing allowlist-extraction step runs. That way, every caller's real PR review picks up the shared rule, with no per-repo copy to keep in sync.

The canonical file also carries over six sub-rules from [Auth's closed doc-only PR](https://github.com/Expensify/Auth/pull/22682): no em dashes, no redundant parentheticals, no stacked hyphenated modifiers, no `->` arrows, no semicolons, and no trailing comments. [The tracking issue](https://github.com/Expensify/Expensify/issues/657167) exists specifically to replace that PR, so seeding the canonical file with only today's short stub would have missed the point.

Follow-up PRs in Auth, Web-Expensify, and App will bump their pinned `claude-review-toolkit@<sha>`, delete their now-redundant local GEN-04 copy, and update `code-inline-reviewer.md`'s docs-link generation once this merges.

### Related Issues
https://github.com/Expensify/Expensify/issues/657167

### Manual Tests
Simulated the copy step locally against a test workspace with an existing local rule file, then ran `extractAllowedRules.sh` on the result and confirmed it extracts both `GEN-01` (local) and `GEN-04` (shared) with no duplicates. Diffed the canonical file against Auth's live `gen-04-commenting-why.md` and against the diff of [Auth's closed doc-only PR](https://github.com/Expensify/Auth/pull/22682) to confirm both the base rule and the appended sub-rules are byte-identical to their sources.

### Linked PRs
None yet. Auth, Web-Expensify, and App consumer PRs will be linked here once opened, after this PR merges and its commit SHA is known.
