### PR TITLE
Add fallback for 1Password /latest endpoint outages in setup-certificate-1p

### DIFF
--- a/setup-certificate-1p/action.yml
+++ b/setup-certificate-1p/action.yml
@@ -34,9 +34,12 @@ runs:
           # Anchor on the per-release id=1password-cli-X.Y.Z headings on the changelog page.
           # A looser number-shaped regex over the whole page also matches SVG path coordinates
           # (e.g. 2.85714286.0), which would then be handed to the install action and 404.
+          # sort -V is GNU-only; the composite action runs on macOS (BSD sort) too,
+          # so compare numerically across the three dotted fields with POSIX sort.
           version=$(curl -sSf -m 10 https://releases.1password.com/developers/cli/ 2>/dev/null \
                     | grep -oE '1password-cli-[0-9]+\.[0-9]+\.[0-9]+' \
-                    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -V -u | tail -1)
+                    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+                    | sort -u -t. -k1,1n -k2,2n -k3,3n | tail -1)
         fi
 
         if [ -z "$version" ]; then

--- a/setup-certificate-1p/action.yml
+++ b/setup-certificate-1p/action.yml
@@ -13,8 +13,44 @@ inputs:
 runs:
   using: composite
   steps:
+    # 1password/install-cli-action calls https://app-updates.agilebits.com/latest to resolve "latest"
+    # to a concrete version, and that endpoint has degraded before (see
+    # https://github.com/1Password/install-cli-action/issues/42). Resolve the version ourselves so we
+    # can fall back to the S3-backed changelog page on releases.1password.com when the primary
+    # resolver is down, and pass a concrete version to the install action.
+    - name: Resolve 1Password CLI version
+      id: opVersion
+      shell: bash
+      run: |
+        set -uo pipefail
+        version=""
+
+        if resp=$(curl -sSf -m 10 https://app-updates.agilebits.com/latest 2>/dev/null); then
+          version=$(echo "$resp" | jq -r '.CLI2.release.version // empty')
+        fi
+
+        if [ -z "$version" ]; then
+          echo "::warning title=1Password /latest endpoint degraded::Falling back to changelog scrape at releases.1password.com. See https://github.com/1Password/install-cli-action/issues/42"
+          # Anchor on the per-release id=1password-cli-X.Y.Z headings on the changelog page.
+          # A looser number-shaped regex over the whole page also matches SVG path coordinates
+          # (e.g. 2.85714286.0), which would then be handed to the install action and 404.
+          version=$(curl -sSf -m 10 https://releases.1password.com/developers/cli/ 2>/dev/null \
+                    | grep -oE '1password-cli-[0-9]+\.[0-9]+\.[0-9]+' \
+                    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -V -u | tail -1)
+        fi
+
+        if [ -z "$version" ]; then
+          echo "::error::Unable to determine 1Password CLI version from any source"
+          exit 1
+        fi
+
+        echo "Resolved op CLI version: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Install 1Password CLI
       uses: 1password/install-cli-action@9a0c9dd934086b7ab1d90115d455bda1c53c2bdb
+      with:
+        version: ${{ steps.opVersion.outputs.version }}
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
 


### PR DESCRIPTION
### Details
Follow-up to [#84](https://github.com/Expensify/GitHub-Actions/pull/84), which added the same fallback to `setupGitForOSBotify`. Georgia flagged in that PR that [`setup-certificate-1p/action.yml`](https://github.com/Expensify/GitHub-Actions/blob/main/setup-certificate-1p/action.yml) has the same vulnerability, and confirmed evidence exists — Ionatan hit it in an Auth PR on 2026-04-09 during a `/latest` outage:

```
Anyone knows why web-e tests in an auth PR could be failing on Setup Mirror Certificates?
Getting latest version number
error: TypeError: fetch failed
at getLatestVersion (...install-cli-action/9a0c9dd934086b7ab1d90115d455bda1c53c2bdb/dist/index.js:32673:17)
```
([Auth run 24194818059 / job 70625239693](https://github.com/Expensify/Auth/actions/runs/24194818059/job/70625239693)) — the SHA in that stack trace matches the install-cli-action pinned in `setup-certificate-1p/action.yml:17` exactly.

Callers that hit this action independently of `setupGitForOSBotify` (i.e. would fail even after [#84](https://github.com/Expensify/GitHub-Actions/pull/84)):
- Expensify/App: `buildIOS`, `buildAndroid`, `androidBump`, various `deploy` jobs
- Expensify/Web-Expensify: `web-expensify`, `agent-zero-full-suite`, `agent-zero-targeted-tests`, `failure-rate-report`
- Expensify/Web-Secure: `web-secure`
- Expensify/Auth: `auth`
- Expensify/FuzzyBot: `fuzzybot`

Applying the same pattern here: pre-flight resolve step with S3 changelog fallback, then pass a concrete `version:` to `install-cli-action` so the flaky endpoint is skipped entirely.

### Related Issues
n/a — infra resilience, no linked issue

### Manual Tests
- Confirmed the primary path: `curl -sSf https://app-updates.agilebits.com/latest | jq -r '.CLI2.release.version'` returns the current version when the endpoint is healthy.
- Confirmed the fallback against the live changelog page returns `2.35.0` (the actual latest release):
  ```
  curl -sSf https://releases.1password.com/developers/cli/ \
    | grep -oE '1password-cli-[0-9]+\.[0-9]+\.[0-9]+' \
    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
    | sort -u -t. -k1,1n -k2,2n -k3,3n | tail -1
  ```
  Anchoring on the per-release `id="1password-cli-X.Y.Z"` headings avoids false matches on SVG path coordinates elsewhere on the page (a loose `\b2\.[0-9]+\.[0-9]+\b` regex picks up `2.85714286.0` from SVG data). Sort uses POSIX numeric key sort across the three dotted fields so it works on macOS BSD `sort` (no `-V`).
- Confirmed via the install-cli-action source that passing a concrete `version:` skips the flaky endpoint and downloads straight from `cache.agilebits.com`.

Once merged, the next run of any caller workflow will exercise the primary path end-to-end.

### Linked PRs
- [#84](https://github.com/Expensify/GitHub-Actions/pull/84) — same fix applied to `setupGitForOSBotify/action.yml`
